### PR TITLE
fix: return actual success from checkIntoMatch and validate relay fragment params

### DIFF
--- a/src/matches/match-relay/match-relay.controller.ts
+++ b/src/matches/match-relay/match-relay.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Req,
-  Res,
-  Param,
-  ParseIntPipe,
-} from "@nestjs/common";
+import { Controller, Get, Post, Req, Res, Param } from "@nestjs/common";
 import { Request, Response } from "express";
 import { MatchRelayService } from "./match-relay.service";
 
@@ -26,22 +18,22 @@ export class MatchRelayController {
   @Get(":fragment/start")
   public handleGetStart(
     @Param("id") matchId: string,
-    @Param("fragment", ParseIntPipe) fragment: number,
+    @Param("fragment") fragment: string,
     @Res() response: Response,
   ) {
-    this.matchRelayService.getStart(response, matchId, fragment);
+    this.matchRelayService.getStart(response, matchId, parseInt(fragment));
   }
 
   @Get(":fragment/full")
   public handleGetFull(
     @Param("id") matchId: string,
-    @Param("fragment", ParseIntPipe) fragment: number,
+    @Param("fragment") fragment: string,
     @Res() response: Response,
   ) {
     this.matchRelayService.getFragment(
       response,
       matchId,
-      fragment,
+      parseInt(fragment),
       "full",
     );
   }
@@ -49,13 +41,13 @@ export class MatchRelayController {
   @Get(":fragment/delta")
   public handleGetDelta(
     @Param("id") matchId: string,
-    @Param("fragment", ParseIntPipe) fragment: number,
+    @Param("fragment") fragment: string,
     @Res() response: Response,
   ) {
     this.matchRelayService.getFragment(
       response,
       matchId,
-      fragment,
+      parseInt(fragment),
       "delta",
     );
   }
@@ -63,22 +55,22 @@ export class MatchRelayController {
   @Get(":token/:fragment/start")
   public handleGetStartWithToken(
     @Param("id") matchId: string,
-    @Param("fragment", ParseIntPipe) fragment: number,
+    @Param("fragment") fragment: string,
     @Res() response: Response,
   ) {
-    this.matchRelayService.getStart(response, matchId, fragment);
+    this.matchRelayService.getStart(response, matchId, parseInt(fragment));
   }
 
   @Get(":token/:fragment/full")
   public handleGetFullWithToken(
     @Param("id") matchId: string,
-    @Param("fragment", ParseIntPipe) fragment: number,
+    @Param("fragment") fragment: string,
     @Res() response: Response,
   ) {
     this.matchRelayService.getFragment(
       response,
       matchId,
-      fragment,
+      parseInt(fragment),
       "full",
     );
   }
@@ -86,13 +78,13 @@ export class MatchRelayController {
   @Get(":token/:fragment/delta")
   public handleGetDeltaWithToken(
     @Param("id") matchId: string,
-    @Param("fragment", ParseIntPipe) fragment: number,
+    @Param("fragment") fragment: string,
     @Res() response: Response,
   ) {
     this.matchRelayService.getFragment(
       response,
       matchId,
-      fragment,
+      parseInt(fragment),
       "delta",
     );
   }
@@ -101,7 +93,7 @@ export class MatchRelayController {
   public async handlePostStart(
     @Param("token") token: string,
     @Param("id") matchId: string,
-    @Param("fragment", ParseIntPipe) fragment: number,
+    @Param("fragment") fragment: string,
     @Req() request: Request,
     @Res() response: Response,
   ) {
@@ -111,7 +103,7 @@ export class MatchRelayController {
       token,
       "start",
       matchId,
-      fragment,
+      parseInt(fragment),
     );
   }
 
@@ -119,7 +111,7 @@ export class MatchRelayController {
   public async handlePostFull(
     @Param("token") token: string,
     @Param("id") matchId: string,
-    @Param("fragment", ParseIntPipe) fragment: number,
+    @Param("fragment") fragment: string,
     @Req() request: Request,
     @Res() response: Response,
   ) {
@@ -129,7 +121,7 @@ export class MatchRelayController {
       token,
       "full",
       matchId,
-      fragment,
+      parseInt(fragment),
     );
   }
 
@@ -137,7 +129,7 @@ export class MatchRelayController {
   public async handlePostDelta(
     @Param("token") token: string,
     @Param("id") matchId: string,
-    @Param("fragment", ParseIntPipe) fragment: number,
+    @Param("fragment") fragment: string,
     @Req() request: Request,
     @Res() response: Response,
   ) {
@@ -147,7 +139,7 @@ export class MatchRelayController {
       token,
       "delta",
       matchId,
-      fragment,
+      parseInt(fragment),
     );
   }
 }

--- a/src/matches/match-relay/match-relay.controller.ts
+++ b/src/matches/match-relay/match-relay.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Req, Res, Param } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  Post,
+  Req,
+  Res,
+  Param,
+  ParseIntPipe,
+} from "@nestjs/common";
 import { Request, Response } from "express";
 import { MatchRelayService } from "./match-relay.service";
 
@@ -18,22 +26,22 @@ export class MatchRelayController {
   @Get(":fragment/start")
   public handleGetStart(
     @Param("id") matchId: string,
-    @Param("fragment") fragment: string,
+    @Param("fragment", ParseIntPipe) fragment: number,
     @Res() response: Response,
   ) {
-    this.matchRelayService.getStart(response, matchId, parseInt(fragment));
+    this.matchRelayService.getStart(response, matchId, fragment);
   }
 
   @Get(":fragment/full")
   public handleGetFull(
     @Param("id") matchId: string,
-    @Param("fragment") fragment: string,
+    @Param("fragment", ParseIntPipe) fragment: number,
     @Res() response: Response,
   ) {
     this.matchRelayService.getFragment(
       response,
       matchId,
-      parseInt(fragment),
+      fragment,
       "full",
     );
   }
@@ -41,13 +49,13 @@ export class MatchRelayController {
   @Get(":fragment/delta")
   public handleGetDelta(
     @Param("id") matchId: string,
-    @Param("fragment") fragment: string,
+    @Param("fragment", ParseIntPipe) fragment: number,
     @Res() response: Response,
   ) {
     this.matchRelayService.getFragment(
       response,
       matchId,
-      parseInt(fragment),
+      fragment,
       "delta",
     );
   }
@@ -55,22 +63,22 @@ export class MatchRelayController {
   @Get(":token/:fragment/start")
   public handleGetStartWithToken(
     @Param("id") matchId: string,
-    @Param("fragment") fragment: string,
+    @Param("fragment", ParseIntPipe) fragment: number,
     @Res() response: Response,
   ) {
-    this.matchRelayService.getStart(response, matchId, parseInt(fragment));
+    this.matchRelayService.getStart(response, matchId, fragment);
   }
 
   @Get(":token/:fragment/full")
   public handleGetFullWithToken(
     @Param("id") matchId: string,
-    @Param("fragment") fragment: string,
+    @Param("fragment", ParseIntPipe) fragment: number,
     @Res() response: Response,
   ) {
     this.matchRelayService.getFragment(
       response,
       matchId,
-      parseInt(fragment),
+      fragment,
       "full",
     );
   }
@@ -78,13 +86,13 @@ export class MatchRelayController {
   @Get(":token/:fragment/delta")
   public handleGetDeltaWithToken(
     @Param("id") matchId: string,
-    @Param("fragment") fragment: string,
+    @Param("fragment", ParseIntPipe) fragment: number,
     @Res() response: Response,
   ) {
     this.matchRelayService.getFragment(
       response,
       matchId,
-      parseInt(fragment),
+      fragment,
       "delta",
     );
   }
@@ -93,7 +101,7 @@ export class MatchRelayController {
   public async handlePostStart(
     @Param("token") token: string,
     @Param("id") matchId: string,
-    @Param("fragment") fragment: string,
+    @Param("fragment", ParseIntPipe) fragment: number,
     @Req() request: Request,
     @Res() response: Response,
   ) {
@@ -103,7 +111,7 @@ export class MatchRelayController {
       token,
       "start",
       matchId,
-      parseInt(fragment),
+      fragment,
     );
   }
 
@@ -111,7 +119,7 @@ export class MatchRelayController {
   public async handlePostFull(
     @Param("token") token: string,
     @Param("id") matchId: string,
-    @Param("fragment") fragment: string,
+    @Param("fragment", ParseIntPipe) fragment: number,
     @Req() request: Request,
     @Res() response: Response,
   ) {
@@ -121,7 +129,7 @@ export class MatchRelayController {
       token,
       "full",
       matchId,
-      parseInt(fragment),
+      fragment,
     );
   }
 
@@ -129,7 +137,7 @@ export class MatchRelayController {
   public async handlePostDelta(
     @Param("token") token: string,
     @Param("id") matchId: string,
-    @Param("fragment") fragment: string,
+    @Param("fragment", ParseIntPipe) fragment: number,
     @Req() request: Request,
     @Res() response: Response,
   ) {
@@ -139,7 +147,7 @@ export class MatchRelayController {
       token,
       "delta",
       matchId,
-      parseInt(fragment),
+      fragment,
     );
   }
 }

--- a/src/matches/matches.controller.ts
+++ b/src/matches/matches.controller.ts
@@ -762,7 +762,7 @@ export class MatchesController {
       throw Error("match is not accepting check in's at this time");
     }
 
-    await this.hasura.mutation({
+    const { update_match_lineup_players } = await this.hasura.mutation({
       update_match_lineup_players: {
         __args: {
           where: {
@@ -826,7 +826,7 @@ export class MatchesController {
     });
 
     return {
-      success: false,
+      success: (update_match_lineup_players?.affected_rows ?? 0) > 0,
     };
   }
 


### PR DESCRIPTION
## Summary
- **checkIntoMatch**: Was always returning `success: false` regardless of outcome. Now returns `true` when the player's check-in mutation affects rows.
- **match-relay controller**: Replaced raw `parseInt(fragment)` with NestJS `ParseIntPipe` — returns 400 Bad Request on non-numeric fragment values instead of passing NaN downstream.

**Note:** The veto condition at line 455 was reviewed and found to be correct (uses `&&` within branches, `||` between them). No change needed.

## Test plan
- [ ] Check into a match as a player — API returns `success: true`
- [ ] Check into match with invalid state — returns error as before
- [ ] Access relay with valid fragment number — works normally
- [ ] Access relay with non-numeric fragment (e.g., `abc`) — returns 400

Closes 5stackgg/5stack-panel#380