### PR TITLE
fix: log rejected game server WebSocket connections

### DIFF
--- a/src/matches/match-events.gateway.ts
+++ b/src/matches/match-events.gateway.ts
@@ -43,12 +43,16 @@ export class MatchEventsGateway {
       const authHeader = request.headers.authorization;
 
       if (!authHeader || !authHeader.startsWith("Basic ")) {
+        this.logger.warn("game server connection rejected: missing auth", {
+          ip: request.headers["cf-connecting-ip"],
+        });
         client.close();
         return;
       }
 
       const base64Credentials = authHeader.split(" ").at(1);
       if (!base64Credentials) {
+        this.logger.warn("game server connection rejected: malformed auth");
         client.close();
         return;
       }
@@ -56,6 +60,7 @@ export class MatchEventsGateway {
       const decoded = Buffer.from(base64Credentials, "base64").toString();
       const colonIndex = decoded.indexOf(":");
       if (colonIndex === -1) {
+        this.logger.warn("game server connection rejected: invalid credentials format");
         client.close();
         return;
       }

--- a/src/matches/match-events.gateway.ts
+++ b/src/matches/match-events.gateway.ts
@@ -52,7 +52,9 @@ export class MatchEventsGateway {
 
       const base64Credentials = authHeader.split(" ").at(1);
       if (!base64Credentials) {
-        this.logger.warn("game server connection rejected: malformed auth");
+        this.logger.warn("game server connection rejected: malformed auth", {
+          ip: request.headers["cf-connecting-ip"],
+        });
         client.close();
         return;
       }
@@ -60,7 +62,9 @@ export class MatchEventsGateway {
       const decoded = Buffer.from(base64Credentials, "base64").toString();
       const colonIndex = decoded.indexOf(":");
       if (colonIndex === -1) {
-        this.logger.warn("game server connection rejected: invalid credentials format");
+        this.logger.warn("game server connection rejected: invalid credentials format", {
+          ip: request.headers["cf-connecting-ip"],
+        });
         client.close();
         return;
       }


### PR DESCRIPTION
## Summary
Follow-up to #137 (merged). Adds warning logs when game server WebSocket connections are rejected for security monitoring:
- Missing auth header (includes client IP)
- Malformed auth credentials
- Invalid credentials format

## Test plan
- [ ] Connect without auth header — warning logged
- [ ] Connect with malformed Basic auth — warning logged