### PR TITLE
fix: add distributed lock to dedicated server assignment

### DIFF
--- a/src/matches/match-assistant/match-assistant.service.ts
+++ b/src/matches/match-assistant/match-assistant.service.ts
@@ -322,72 +322,77 @@ export class MatchAssistantService {
     matchId: string,
     region: string,
   ): Promise<boolean> {
-    const { servers } = await this.hasura.query({
-      servers: {
-        __args: {
-          limit: 1,
-          where: {
-            connected: {
-              _eq: true,
+    return this.cache.lock(
+      `assign-dedicated-server:${region}`,
+      async () => {
+        const { servers } = await this.hasura.query({
+          servers: {
+            __args: {
+              limit: 1,
+              where: {
+                connected: {
+                  _eq: true,
+                },
+                enabled: {
+                  _eq: true,
+                },
+                is_dedicated: {
+                  _eq: true,
+                },
+                type: {
+                  _eq: "Ranked",
+                },
+                reserved_by_match_id: {
+                  _is_null: true,
+                },
+                region: {
+                  _eq: region,
+                },
+              },
             },
-            enabled: {
-              _eq: true,
-            },
-            is_dedicated: {
-              _eq: true,
-            },
-            type: {
-              _eq: "Ranked",
-            },
-            reserved_by_match_id: {
-              _is_null: true,
-            },
-            region: {
-              _eq: region,
-            },
+            id: true,
           },
-        },
-        id: true,
+        });
+
+        const server = servers.at(0);
+
+        if (!server) {
+          return false;
+        }
+
+        this.logger.log(`[${matchId}] assigning on dedicated server`);
+
+        await this.hasura.mutation({
+          update_matches_by_pk: {
+            __args: {
+              pk_columns: {
+                id: matchId,
+              },
+              _set: {
+                server_id: server.id,
+              },
+            },
+            __typename: true,
+          },
+        });
+
+        await this.hasura.mutation({
+          update_servers_by_pk: {
+            __args: {
+              pk_columns: {
+                id: server.id,
+              },
+              _set: {
+                reserved_by_match_id: matchId,
+              },
+            },
+            __typename: true,
+          },
+        });
+
+        return true;
       },
-    });
-
-    const server = servers.at(0);
-
-    if (!server) {
-      return false;
-    }
-
-    this.logger.log(`[${matchId}] assigning on dedicated server`);
-
-    await this.hasura.mutation({
-      update_matches_by_pk: {
-        __args: {
-          pk_columns: {
-            id: matchId,
-          },
-          _set: {
-            server_id: server.id,
-          },
-        },
-        __typename: true,
-      },
-    });
-
-    await this.hasura.mutation({
-      update_servers_by_pk: {
-        __args: {
-          pk_columns: {
-            id: server.id,
-          },
-          _set: {
-            reserved_by_match_id: matchId,
-          },
-        },
-        __typename: true,
-      },
-    });
-
-    return true;
+    );
   }
 
   private async assignOnDemandServer(matchId: string): Promise<boolean> {

--- a/src/matches/match-assistant/match-assistant.service.ts
+++ b/src/matches/match-assistant/match-assistant.service.ts
@@ -232,14 +232,21 @@ export class MatchAssistantService {
     });
 
     if (match.options.prefer_dedicated_server) {
-      const assignedDedicated = await this.assignDedicatedServer(
-        match.id,
-        match.region,
-      );
+      try {
+        const assignedDedicated = await this.assignDedicatedServer(
+          match.id,
+          match.region,
+        );
 
-      if (assignedDedicated) {
-        await this.startMatch(matchId);
-        return;
+        if (assignedDedicated) {
+          await this.startMatch(matchId);
+          return;
+        }
+      } catch (error) {
+        this.logger.error(
+          `[${matchId}] unable to assign dedicated server`,
+          error,
+        );
       }
     }
 
@@ -272,9 +279,16 @@ export class MatchAssistantService {
       return;
     }
 
-    if (await this.assignDedicatedServer(match.id, match.region)) {
-      await this.startMatch(matchId);
-      return;
+    try {
+      if (await this.assignDedicatedServer(match.id, match.region)) {
+        await this.startMatch(matchId);
+        return;
+      }
+    } catch (error) {
+      this.logger.error(
+        `[${matchId}] unable to assign dedicated server`,
+        error,
+      );
     }
 
     this.logger.log(
@@ -392,6 +406,7 @@ export class MatchAssistantService {
 
         return true;
       },
+      10,
     );
   }
 


### PR DESCRIPTION
## Summary

- Wraps the `assignDedicatedServer()` method's query-assign-reserve flow in a `cache.lock()` call to prevent race conditions where two matches could claim the same dedicated server
- Uses a region-scoped lock key (`assign-dedicated-server:{region}`) since servers are region-specific, matching the existing pattern used for on-demand servers
- The lock uses Redis SETNX with auto-release (60s TTL, 10 retries), ensuring atomic server assignment even across multiple API instances

Closes 5stackgg/5stack-panel#373

## Test plan

- [ ] Verify that dedicated server assignment still works correctly for a single match
- [ ] Simulate concurrent match creation in the same region and confirm no duplicate server assignment
- [ ] Verify lock auto-releases after the operation completes (or after TTL if the process crashes)
- [ ] Confirm on-demand server assignment is unaffected