### PR TITLE
fix: add ELO calculation retry and dedicated server state recovery

### DIFF
--- a/src/dedicated-servers/dedicated-servers.service.ts
+++ b/src/dedicated-servers/dedicated-servers.service.ts
@@ -345,17 +345,11 @@ export class DedicatedServersService {
             await this.pingDedicatedServer(serverId);
           }, 10000);
         })
-        .catch(async (error) => {
+        .catch((error) => {
           this.logger.error(
-            `[${serverId}] error waiting for pod to be ready, recovering server state`,
+            `[${serverId}] error waiting for pod to be ready`,
             error,
           );
-          await this.removeDedicatedServer(serverId).catch((removeError) => {
-            this.logger.error(
-              `[${serverId}] failed to clean up server after pod readiness failure`,
-              removeError,
-            );
-          });
         });
 
       return true;

--- a/src/dedicated-servers/dedicated-servers.service.ts
+++ b/src/dedicated-servers/dedicated-servers.service.ts
@@ -345,11 +345,17 @@ export class DedicatedServersService {
             await this.pingDedicatedServer(serverId);
           }, 10000);
         })
-        .catch((error) => {
+        .catch(async (error) => {
           this.logger.error(
-            `[${serverId}] error waiting for pod to be ready`,
+            `[${serverId}] error waiting for pod to be ready, recovering server state`,
             error,
           );
+          await this.removeDedicatedServer(serverId).catch((removeError) => {
+            this.logger.error(
+              `[${serverId}] failed to clean up server after pod readiness failure`,
+              removeError,
+            );
+          });
         });
 
       return true;

--- a/src/matches/jobs/EloCalculation.ts
+++ b/src/matches/jobs/EloCalculation.ts
@@ -7,9 +7,10 @@ import { PostgresService } from "../../postgres/postgres.service";
 
 @UseQueue("Matches", MatchQueues.EloCalculation)
 export class EloCalculation extends WorkerHost {
-  private readonly logger = new Logger(EloCalculation.name);
-
-  constructor(private readonly postgres: PostgresService) {
+  constructor(
+    private readonly logger: Logger,
+    private readonly postgres: PostgresService,
+  ) {
     super();
   }
 

--- a/src/matches/jobs/EloCalculation.ts
+++ b/src/matches/jobs/EloCalculation.ts
@@ -1,11 +1,14 @@
 import { Job } from "bullmq";
 import { WorkerHost } from "@nestjs/bullmq";
+import { Logger } from "@nestjs/common";
 import { MatchQueues } from "../enums/MatchQueues";
 import { UseQueue } from "../../utilities/QueueProcessors";
 import { PostgresService } from "../../postgres/postgres.service";
 
 @UseQueue("Matches", MatchQueues.EloCalculation)
 export class EloCalculation extends WorkerHost {
+  private readonly logger = new Logger(EloCalculation.name);
+
   constructor(private readonly postgres: PostgresService) {
     super();
   }
@@ -13,11 +16,19 @@ export class EloCalculation extends WorkerHost {
   async process(job: Job): Promise<void> {
     const { matchId } = job.data;
 
-    await this.postgres.query(
-      `
-      SELECT generate_player_elo_for_match($1)
-    `,
-      [matchId],
-    );
+    try {
+      await this.postgres.query(
+        `
+        SELECT generate_player_elo_for_match($1)
+      `,
+        [matchId],
+      );
+    } catch (error) {
+      this.logger.error(
+        `ELO calculation failed for match ${matchId} (attempt ${job.attemptsMade + 1})`,
+        error,
+      );
+      throw error;
+    }
   }
 }

--- a/src/matches/matches.module.ts
+++ b/src/matches/matches.module.ts
@@ -75,6 +75,10 @@ import { DiscordTournamentVoiceModule } from "../discord-bot/discord-tournament-
       },
       {
         name: MatchQueues.EloCalculation,
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: { type: "exponential", delay: 5000 },
+        },
       },
     ),
     BullBoardModule.forFeature(


### PR DESCRIPTION
## Summary
- Add try/catch with logging around ELO calculation postgres query, re-throwing for BullMQ retry
- Configure ELO calculation queue with exponential backoff retry (3 attempts, 5s initial delay)
- Recover dedicated server state when pod readiness check fails (clean up deployment instead of leaving server in disconnected state)

Addresses 5stackgg/5stack-panel#377

## Test plan
- [ ] Verify ELO calculation retries on transient postgres failures
- [ ] Verify dedicated server cleanup occurs when pod fails to become ready
- [ ] Confirm normal ELO calculation and server setup paths still work