### PR TITLE
bug: fix round robin -> next stage advancement for grouped RR

### DIFF
--- a/hasura/functions/tournaments/get_stage_team_counts.sql
+++ b/hasura/functions/tournaments/get_stage_team_counts.sql
@@ -26,11 +26,12 @@ BEGIN
                 SELECT type, max_teams INTO previous_stage_type, previous_stage_max_teams
                 FROM tournament_stages
                 WHERE tournament_id = _tournament_id AND "order" = _stage_order - 1;
-                
-                -- For RoundRobin stages, use max_teams (all teams can advance)
-                -- For elimination stages, count matches in last round (each match = 1 advancing team)
+
+                -- For RoundRobin stages, only the top teams advance, capped by this
+                -- stage's max_teams. Using the previous stage's max_teams here would
+                -- size brackets for every team in the RR, not just the qualifiers.
                 IF previous_stage_type = 'RoundRobin' THEN
-                    effective_teams := previous_stage_max_teams;
+                    effective_teams := LEAST(stage_max_teams, previous_stage_max_teams);
                 ELSE
                     -- get the number of matches from the last round of the previous stage
                     SELECT COUNT(*) INTO effective_teams

--- a/hasura/functions/tournaments/get_team_at_stage_rank.sql
+++ b/hasura/functions/tournaments/get_team_at_stage_rank.sql
@@ -1,0 +1,72 @@
+-- Returns the tournament_team_id of the team ranked `_rank` (1-indexed) within
+-- the given stage group, using the same tiebreaker order as v_team_stage_results.
+-- Used by seed_stage to advance per-group qualifiers from a RoundRobin/Swiss
+-- stage into the next stage. The team's group is taken from the brackets it
+-- appears in for that stage (RoundRobin places each team in exactly one group;
+-- Swiss uses a single group).
+CREATE OR REPLACE FUNCTION public.get_team_at_stage_rank(
+    _stage_id uuid,
+    _group int,
+    _rank int
+) RETURNS uuid
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+    result_team_id uuid;
+BEGIN
+    WITH team_groups AS (
+        SELECT team_id, MIN("group") as "group"
+        FROM (
+            SELECT tb.tournament_team_id_1 as team_id, tb."group"
+            FROM tournament_brackets tb
+            WHERE tb.tournament_stage_id = _stage_id
+              AND tb.tournament_team_id_1 IS NOT NULL
+              AND COALESCE(tb.path, 'WB') = 'WB'
+            UNION ALL
+            SELECT tb.tournament_team_id_2 as team_id, tb."group"
+            FROM tournament_brackets tb
+            WHERE tb.tournament_stage_id = _stage_id
+              AND tb.tournament_team_id_2 IS NOT NULL
+              AND COALESCE(tb.path, 'WB') = 'WB'
+        ) sub
+        GROUP BY team_id
+    ),
+    ranked AS (
+        SELECT
+            tg.team_id,
+            tg."group",
+            ROW_NUMBER() OVER (
+                PARTITION BY tg."group"
+                ORDER BY
+                    COALESCE(vtsr.wins, 0) DESC,
+                    COALESCE(vtsr.head_to_head_match_wins, 0) DESC,
+                    COALESCE(vtsr.head_to_head_rounds_won, 0) DESC,
+                    CASE
+                        WHEN COALESCE(vtsr.maps_lost, 0) > 0
+                        THEN (COALESCE(vtsr.maps_won, 0)::float / vtsr.maps_lost::float)
+                        ELSE COALESCE(vtsr.maps_won, 0)::float
+                    END DESC,
+                    CASE
+                        WHEN COALESCE(vtsr.rounds_lost, 0) > 0
+                        THEN (COALESCE(vtsr.rounds_won, 0)::float / vtsr.rounds_lost::float)
+                        ELSE COALESCE(vtsr.rounds_won, 0)::float
+                    END DESC,
+                    COALESCE(vtsr.team_kdr, 0) DESC,
+                    tg.team_id ASC
+            ) as rank_in_group
+        FROM team_groups tg
+        INNER JOIN tournament_teams tt
+            ON tt.id = tg.team_id
+            AND tt.eligible_at IS NOT NULL
+        LEFT JOIN v_team_stage_results vtsr
+            ON vtsr.tournament_team_id = tg.team_id
+            AND vtsr.tournament_stage_id = _stage_id
+    )
+    SELECT team_id INTO result_team_id
+    FROM ranked
+    WHERE "group" = _group
+      AND rank_in_group = _rank;
+
+    RETURN result_team_id;
+END;
+$$;

--- a/hasura/functions/tournaments/seed_stage.sql
+++ b/hasura/functions/tournaments/seed_stage.sql
@@ -108,25 +108,30 @@ BEGIN
             -- For elimination brackets coming from RoundRobin/Swiss stages, use stage results
             -- Otherwise, lookup teams by seed
             IF previous_stage.id IS NOT NULL AND (previous_stage.type = 'RoundRobin' OR previous_stage.type = 'Swiss') THEN
-                IF team_1_seed_val IS NOT NULL THEN
-                    SELECT vtsr.tournament_team_id INTO team_1_id
-                    FROM v_team_stage_results vtsr
-                    JOIN tournament_teams tt ON tt.id = vtsr.tournament_team_id
-                    WHERE vtsr.tournament_stage_id = previous_stage.id
-                      AND tt.eligible_at IS NOT NULL
-                    OFFSET team_1_seed_val - 1
-                    LIMIT 1;
-                END IF;
+                -- Map next-stage seed N to (group, rank_in_group) of the previous
+                -- stage so groups cross-seed: with G groups, seed 1 = top of group 1,
+                -- seed 2 = top of group 2, seed G+1 = 2nd of group 1, and so on.
+                -- Falls back to a single group for Swiss (or RR with groups = 1),
+                -- which degenerates to plain top-N ordering.
+                DECLARE
+                    prev_groups int;
+                    group_idx int;
+                    rank_in_group int;
+                BEGIN
+                    prev_groups := GREATEST(COALESCE(previous_stage.groups, 1), 1);
 
-                IF team_2_seed_val IS NOT NULL THEN
-                    SELECT vtsr.tournament_team_id INTO team_2_id
-                    FROM v_team_stage_results vtsr
-                    JOIN tournament_teams tt ON tt.id = vtsr.tournament_team_id
-                    WHERE vtsr.tournament_stage_id = previous_stage.id
-                      AND tt.eligible_at IS NOT NULL
-                    OFFSET team_2_seed_val - 1
-                    LIMIT 1;
-                END IF;
+                    IF team_1_seed_val IS NOT NULL THEN
+                        group_idx := ((team_1_seed_val - 1) % prev_groups) + 1;
+                        rank_in_group := ((team_1_seed_val - 1) / prev_groups) + 1;
+                        team_1_id := get_team_at_stage_rank(previous_stage.id, group_idx, rank_in_group);
+                    END IF;
+
+                    IF team_2_seed_val IS NOT NULL THEN
+                        group_idx := ((team_2_seed_val - 1) % prev_groups) + 1;
+                        rank_in_group := ((team_2_seed_val - 1) / prev_groups) + 1;
+                        team_2_id := get_team_at_stage_rank(previous_stage.id, group_idx, rank_in_group);
+                    END IF;
+                END;
             ELSE
                 -- Find team with matching seed for position 1
                 IF team_1_seed_val IS NOT NULL THEN


### PR DESCRIPTION
When a Live tournament transitioned from a multi-group RoundRobin stage to
the next stage, get_stage_team_counts was setting effective_teams to the
RR stage's own max_teams, so update_tournament_stages sized the next
stage's brackets for every team in the RR instead of the qualifying
top N. Cap effective_teams to LEAST(stage_max_teams, previous_stage_max_teams).

seed_stage was also picking advancing teams from v_team_stage_results
with a global OFFSET, ignoring groups - so with 2 groups taking top 2,
all four advancing slots could pull from one group. Map next-stage seed
N to (group ((N-1) % G + 1), rank ((N-1) / G + 1)) of the previous stage
via a new get_team_at_stage_rank helper, so seeds cross-seed across
groups (A1 vs B2, B1 vs A2). Single-group RR and Swiss degenerate to
plain top-N ordering.

https://claude.ai/code/session_01Uh5BFtHve7jGwEuEwpqLBt