### PR TITLE
bug: fix round robin pairings for odd team counts

### DIFF
--- a/hasura/functions/tournaments/create_round_robin_matches.sql
+++ b/hasura/functions/tournaments/create_round_robin_matches.sql
@@ -12,22 +12,23 @@ LANGUAGE plpgsql
 AS $$
 DECLARE
     team_count int;
+    effective_count int;       -- team_count, or team_count + 1 with a phantom slot
+    has_phantom boolean;       -- true when team_count is odd
     round_count int;
-    matches_per_round int;
+    matches_per_round int;     -- real matches per round (excludes the phantom pair)
 
     round_num int;
-    i int;
     k int;
     rotated_idx int;
     rotation_offset int;
+    rotated_positions int[];
+    pos1 int;
+    pos2 int;
+    match_idx int;
     team_1_id uuid;
     team_2_id uuid;
     team_1_seed int;
     team_2_seed int;
-    rotated_teams uuid[];
-    rotated_seeds int[];
-    idx1 int;
-    idx2 int;
     bracket_record tournament_brackets%ROWTYPE;
     use_team_ids boolean;
 BEGIN
@@ -41,73 +42,73 @@ BEGIN
     ELSE
         RAISE EXCEPTION 'Need either team_ids or team_seeds array' USING ERRCODE = '22000';
     END IF;
-    
+
     IF team_count < 2 THEN
         RAISE EXCEPTION 'Need at least 2 teams for round robin, got %', team_count USING ERRCODE = '22000';
     END IF;
-    
-    -- Calculate rounds needed for round robin
+
+    -- Circle method: with N (even) slots, rotate slots 2..N around the fixed
+    -- slot 1 and pair across. For odd team counts we add a phantom slot at the
+    -- end; the team paired with the phantom that round is the one that sits
+    -- out, which is the only way to guarantee every team plays every other
+    -- exactly once with no duplicates.
     IF team_count % 2 = 0 THEN
-        round_count := team_count - 1;
+        effective_count := team_count;
+        has_phantom := false;
         matches_per_round := team_count / 2;
     ELSE
-        round_count := team_count;
+        effective_count := team_count + 1;
+        has_phantom := true;
         matches_per_round := (team_count - 1) / 2;
     END IF;
-    
-    RAISE NOTICE 'Creating round robin matches for % teams: % rounds, % matches per round, starting at round %', 
+    round_count := effective_count - 1;
+
+    RAISE NOTICE 'Creating round robin matches for % teams: % rounds, % matches per round, starting at round %',
         team_count, round_count, matches_per_round, _start_round;
-    
-    -- Generate round robin matches using rotating algorithm
+
     FOR round_num IN 1..round_count LOOP
-        IF use_team_ids THEN
-            -- Create rotated array for this round (using team IDs)
-            rotated_teams := ARRAY[]::uuid[];
-            rotated_teams := rotated_teams || _team_ids[1];
-            
-            rotation_offset := (round_num - 1) % (team_count - 1);
-            
-            FOR k IN 1..(team_count - 1) LOOP
-                rotated_idx := 1 + ((k - 1 + rotation_offset) % (team_count - 1)) + 1;
-                rotated_teams := rotated_teams || _team_ids[rotated_idx];
-            END LOOP;
-        ELSE
-            -- Create rotated array for this round (using seeds)
-            rotated_seeds := ARRAY[]::int[];
-            rotated_seeds := rotated_seeds || _team_seeds[1];
-            
-            rotation_offset := (round_num - 1) % (team_count - 1);
-            
-            FOR k IN 1..(team_count - 1) LOOP
-                rotated_idx := 1 + ((k - 1 + rotation_offset) % (team_count - 1)) + 1;
-                rotated_seeds := rotated_seeds || _team_seeds[rotated_idx];
-            END LOOP;
-        END IF;
-        
-        -- Pair teams: first with last, second with second-to-last, etc.
-        FOR i IN 1..matches_per_round LOOP
-            idx1 := i;
-            idx2 := team_count + 1 - i;
-            
+        -- Build slot positions for this round. Slot 1 is fixed; slots
+        -- 2..effective_count rotate. Cycling over (effective_count - 1)
+        -- guarantees each round is unique.
+        rotation_offset := (round_num - 1) % (effective_count - 1);
+
+        rotated_positions := ARRAY[1]::int[];
+        FOR k IN 1..(effective_count - 1) LOOP
+            rotated_idx := ((k - 1 + rotation_offset) % (effective_count - 1)) + 2;
+            rotated_positions := rotated_positions || rotated_idx;
+        END LOOP;
+
+        match_idx := 0;
+        FOR k IN 1..(effective_count / 2) LOOP
+            pos1 := rotated_positions[k];
+            pos2 := rotated_positions[effective_count + 1 - k];
+
+            -- The phantom occupies slot (team_count + 1); whichever real team
+            -- is paired with it that round gets the bye, so emit no bracket.
+            IF has_phantom AND (pos1 > team_count OR pos2 > team_count) THEN
+                CONTINUE;
+            END IF;
+
+            match_idx := match_idx + 1;
+
             IF use_team_ids THEN
-                team_1_id := rotated_teams[idx1];
-                team_2_id := rotated_teams[idx2];
-                
-                -- Get seeds for these teams
+                team_1_id := _team_ids[pos1];
+                team_2_id := _team_ids[pos2];
+
                 SELECT COALESCE(seed, 999999) INTO team_1_seed
                 FROM tournament_teams
                 WHERE id = team_1_id;
-                
+
                 SELECT COALESCE(seed, 999999) INTO team_2_seed
                 FROM tournament_teams
                 WHERE id = team_2_id;
             ELSE
-                team_1_seed := rotated_seeds[idx1];
-                team_2_seed := rotated_seeds[idx2];
+                team_1_seed := _team_seeds[pos1];
+                team_2_seed := _team_seeds[pos2];
                 team_1_id := NULL;
                 team_2_id := NULL;
             END IF;
-            
+
             INSERT INTO tournament_brackets (
                 round,
                 tournament_stage_id,
@@ -122,7 +123,7 @@ BEGIN
             VALUES (
                 _start_round + round_num - 1,
                 _stage_id,
-                i,
+                match_idx,
                 _group,
                 team_1_seed,
                 team_2_seed,
@@ -133,31 +134,30 @@ BEGIN
 
             IF use_team_ids THEN
                 RAISE NOTICE 'Created match %: round %, team % vs team %',
-                    i, _start_round + round_num - 1, team_1_id, team_2_id;
+                    match_idx, _start_round + round_num - 1, team_1_id, team_2_id;
             ELSE
                 RAISE NOTICE 'Created match %: round %, seed % vs seed %',
-                    i, _start_round + round_num - 1, team_1_seed, team_2_seed;
+                    match_idx, _start_round + round_num - 1, team_1_seed, team_2_seed;
             END IF;
         END LOOP;
     END LOOP;
-    
+
     -- Schedule round 1 matches immediately if requested (only for decider matches with team IDs)
     IF _schedule_round_1 AND use_team_ids THEN
-        FOR bracket_record IN 
-            SELECT * FROM tournament_brackets 
-            WHERE tournament_stage_id = _stage_id 
+        FOR bracket_record IN
+            SELECT * FROM tournament_brackets
+            WHERE tournament_stage_id = _stage_id
               AND round = _start_round
               AND "group" = _group
               AND match_id IS NULL
-              AND tournament_team_id_1 IS NOT NULL 
+              AND tournament_team_id_1 IS NOT NULL
               AND tournament_team_id_2 IS NOT NULL
         LOOP
             PERFORM schedule_tournament_match(bracket_record);
             RAISE NOTICE 'Scheduled round % match: bracket %', _start_round, bracket_record.id;
         END LOOP;
     END IF;
-    
+
     RAISE NOTICE 'Created % round robin matches starting at round %', round_count * matches_per_round, _start_round;
 END;
 $$;
-


### PR DESCRIPTION
## Summary

Round robin groups with an odd number of teams produced duplicate matches and uneven match counts. With 5 teams the schedule was:

- R1: A·E, B·D (C sits)
- R2: A·B, C·E (D sits)
- R3: A·C, B·D (E sits)
- R4: A·D, C·E (B sits)
- R5: A·E, B·D (C sits)  ← duplicate of R1

B·D played 3×, A·E played 2×, B-C / B-E / C-D / D-E never played, and A finished with 5 matches while C only got 3.

The rotation in `create_round_robin_matches` cycled `rotation_offset` modulo `(team_count - 1)`. For even counts that's correct (N-1 distinct rounds). For odd counts you need N rounds, but the modulus only produced N-1 distinct rotations, so round N repeated round 1 — and because pairing always picks the array's middle position as the sit-out, the same team sat out the repeated round too.

Switched to the standard circle method with a phantom slot for odd counts: `effective_count = team_count` (even) or `team_count + 1` (odd, phantom in the last slot). Always run `effective_count - 1` rounds rotating slots 2..N around fixed slot 1 and pairing across the circle; when a real team is paired with the phantom that round, skip the bracket — that team's bye for the round.

Verified by hand for N = 3, 4, 5, 6, 7: every team plays every other exactly once, every team has `team_count - 1` matches, no duplicates.