### PR TITLE
bug: size brackets by actual teams once registration closes

### DIFF
--- a/hasura/functions/tournaments/get_stage_team_counts.sql
+++ b/hasura/functions/tournaments/get_stage_team_counts.sql
@@ -9,8 +9,11 @@ BEGIN
     FROM tournament_stages
     WHERE tournament_id = _tournament_id AND "order" = _stage_order;
 
-    -- If tournament is in Setup status, use max_teams for bracket planning
-    IF _tournament_status != 'Live' AND _tournament_status != 'Finished' THEN
+    -- Only Setup/RegistrationOpen plan the bracket against max_teams; in every
+    -- other status (RegistrationClosed, Live, Paused, Finished, Cancelled*)
+    -- the eligible-team count is final, so size the bracket to that instead
+    -- of padding unfilled slots with byes.
+    IF _tournament_status IN ('Setup', 'RegistrationOpen') THEN
         effective_teams := stage_max_teams;
     ELSE
         IF _stage_order = 1 THEN

--- a/hasura/functions/tournaments/get_stage_team_counts.sql
+++ b/hasura/functions/tournaments/get_stage_team_counts.sql
@@ -20,6 +20,17 @@ BEGIN
             SELECT COUNT(*) INTO effective_teams
                 FROM tournament_teams
                 WHERE tournament_id = _tournament_id AND eligible_at IS NOT NULL;
+
+            -- Downstream bracket math in update_tournament_stages takes
+            -- LOG(teams_per_group), which raises on 0 and produces an empty
+            -- bracket on 1. Before the tournament is Live/Finished the count
+            -- is not yet final, so fall back to max_teams when it can't form
+            -- a valid bracket — admins can still edit stages, and the
+            -- placeholder bracket renders. In Live/Finished we accept the
+            -- real count: those statuses are gated by tournament_has_min_teams.
+            IF effective_teams < 2 AND _tournament_status NOT IN ('Live', 'Finished') THEN
+                effective_teams := stage_max_teams;
+            END IF;
         ELSE
             -- Get the previous stage to check its type
             DECLARE


### PR DESCRIPTION
## Summary
- Single-elimination brackets were being sized to `stage.max_teams` whenever the tournament status was not `Live` or `Finished` — which incorrectly includes `RegistrationClosed`.
- Result: a stage with `max=8` (or `max=7`) and only 4 eligible teams produced an "Opening Round" with 4 bye matches, even though registration was already closed and the final team count was known.
- Restrict `max_teams` sizing to `Setup` and `RegistrationOpen` (the only statuses where more teams can still join). All later statuses now use the actual eligible-team count.

## What changed
Single conditional in `hasura/functions/tournaments/get_stage_team_counts.sql`:

```diff
-IF _tournament_status != 'Live' AND _tournament_status != 'Finished' THEN
+IF _tournament_status IN ('Setup', 'RegistrationOpen') THEN
     effective_teams := stage_max_teams;
```

Status matrix after the fix:

| Status              | Uses `max_teams` | Uses actual count |
|---------------------|:----------------:|:-----------------:|
| Setup               | x                |                   |
| RegistrationOpen    | x                |                   |
| RegistrationClosed  |                  | x (new)           |
| Paused              |                  | x (new)           |
| Cancelled / CancelledMinTeams |        | x (new)           |
| Live                |                  | x (unchanged)     |
| Finished            |                  | x (unchanged)     |

## Why
The downstream call sites (`update_tournament_stages.sql`) cascade `effective_teams` into:
- `teams_per_group = CEIL(effective_teams / groups)`
- `stage_target_size = POWER(2, CEIL(LOG2(teams_per_group)))`
- `bracket_order = generate_bracket_order(effective_teams)`
- `matches_in_round = groups * (stage_target_size / 2)` for round 1

So padding `effective_teams` with non-existent teams creates real bracket rows for those phantom slots, then renders them as "Bye Runde". Sizing by actual teams collapses the bracket to the right shape (4 teams → 2 semis + 1 final, no opening round).

## Test plan
- [ ] In a test tournament (`Setup` status, no teams), confirm the bracket preview still renders against `max_teams` (planning view unchanged).
- [ ] In `RegistrationOpen` status with a partial team list, confirm the bracket preview still shows `max_teams` slots (so organizers can see the planned bracket).
- [ ] Set tournament to `RegistrationClosed` with 4 eligible teams (min=4, max=7 or 8). Verify the Single Elimination stage renders 2 semifinal matches + 1 final, with no "Opening Round" / "Bye Runde" rows.
- [ ] Repeat with 5, 6, 7 eligible teams — verify byes only appear for the genuine power-of-2 gap (e.g. 5 teams → 3 R1 matches + 1 bye into R2).
- [ ] Repeat with 8 eligible teams — full quarterfinals, no byes.
- [ ] Verify existing tournaments that are already `Live` or `Finished` are unaffected (same branch as before).
- [ ] Existing tournaments stuck in `RegistrationClosed` with bad brackets: re-trigger `update_tournament_stages` (e.g. by editing the stage) and confirm the bracket regenerates correctly.

## Notes
- No migration needed; this is a `CREATE OR REPLACE FUNCTION` and the file is loaded by Hasura on deploy.
- Existing tournaments will not auto-regenerate their brackets — they need a stage edit (or any other trigger of `update_tournament_stages`) to pick up the new sizing.