### PR TITLE
Add regression test for post-veto stand-in invites

### DIFF
--- a/src/invites/match-invites.permissions.spec.ts
+++ b/src/invites/match-invites.permissions.spec.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("match invite permissions", () => {
+  const inviteMetadata = readFileSync(
+    join(
+      __dirname,
+      "../../hasura/metadata/databases/default/tables/public_match_invites.yaml",
+    ),
+    "utf8",
+  );
+  const matchesTrigger = readFileSync(
+    join(__dirname, "../../hasura/triggers/matches.sql"),
+    "utf8",
+  );
+
+  it("allows stand-in invites after veto while lineups are still editable", () => {
+    expect(inviteMetadata).toContain("- WaitingForCheckIn");
+    expect(inviteMetadata).toContain("- WaitingForServer");
+    expect(inviteMetadata).toContain("- Veto");
+  });
+
+  it("keeps stand-in invites when matches move through post-veto mutable statuses", () => {
+    expect(matchesTrigger).toContain(
+      "NEW.status NOT IN ('PickingPlayers', 'WaitingForCheckIn', 'WaitingForServer', 'Veto')",
+    );
+  });
+});


### PR DESCRIPTION
Refs 5stackgg/5stack-panel#480

## Summary

Adds a failing regression test for issue 480: filling a stand-in after veto should still be possible while lineups are editable.

The test documents the currently suspected cause:
- match_invites inserts are only permitted while the match is PickingPlayers
- tau_matches deletes match invites as soon as the match leaves PickingPlayers

