### PR TITLE
feature: branded highlight outro (orchestration)

### DIFF
--- a/src/matches/clips/clips.service.ts
+++ b/src/matches/clips/clips.service.ts
@@ -214,6 +214,11 @@ export class ClipsService {
         `dest=${spec.destination}`,
     );
 
+    const outroEnv = await this.gameStreamer.resolveOutroBranding(
+      dims,
+      spec.output.fps,
+    );
+
     try {
       await this.gameStreamer.dispatchClipRenderToPod(session.id, {
         job_id: jobId,
@@ -227,6 +232,7 @@ export class ClipsService {
         })),
         output_dims: dims,
         output_fps: spec.output.fps,
+        outro_env: outroEnv,
       });
     } catch (error) {
       this.logger.error(

--- a/src/matches/clips/clips.service.ts
+++ b/src/matches/clips/clips.service.ts
@@ -214,12 +214,11 @@ export class ClipsService {
         `dest=${spec.destination}`,
     );
 
-    const outroEnv = await this.gameStreamer.resolveOutroBranding(
-      dims,
-      spec.output.fps,
-    );
-
     try {
+      const outroEnv = await this.gameStreamer.resolveOutroBranding(
+        dims,
+        spec.output.fps,
+      );
       await this.gameStreamer.dispatchClipRenderToPod(session.id, {
         job_id: jobId,
         token: sessionToken,

--- a/src/matches/game-streamer/game-streamer.service.ts
+++ b/src/matches/game-streamer/game-streamer.service.ts
@@ -364,6 +364,9 @@ export class GameStreamerService {
       if (!logoPath) {
         return {};
       }
+      // Empty brandName (no public.brand_name) is intentional: the pod renders
+      // a logo-only outro (the Outro composition hides the wordmark). Keep the
+      // CLIP_BRAND_NAME key with an empty value — do not drop it.
       const brandName = (await this.readSetting("public.brand_name")) ?? "";
       const accent =
         (await this.readSetting("public.color_dark_tactical_amber")) ??

--- a/src/matches/game-streamer/game-streamer.service.ts
+++ b/src/matches/game-streamer/game-streamer.service.ts
@@ -839,6 +839,9 @@ export class GameStreamerService {
         name: "CLIP_BAKE_BRANDING",
         value: await this.resolveClipBakeBranding(),
       },
+      // Trusted S3 presign origin for render-clip.mjs's outro-env URL allowlist
+      // (independent of the demo source, so faceit/external demos still brand).
+      { name: "S3_PUBLIC_ORIGIN", value: this.appConfig.demosDomain },
     ];
     if (options.roundTicks != null) {
       env.push({

--- a/src/matches/game-streamer/game-streamer.service.ts
+++ b/src/matches/game-streamer/game-streamer.service.ts
@@ -1121,6 +1121,7 @@ export class GameStreamerService {
       }>;
       output_dims: string;
       output_fps: number;
+      outro_env?: Record<string, string>;
     },
   ) {
     const url = this.getDemoSpecUrl(sessionId, "render-clip", "demo");
@@ -2346,6 +2347,20 @@ export class GameStreamerService {
       name: "CLIP_BAKE_BRANDING",
       value: await this.resolveClipBakeBranding(),
     });
+    {
+      // Batch jobs share the global clip resolution/fps, so the outro env is
+      // computed once at pod level (resolve_outro_file re-validates dims and
+      // falls back, so a mismatch is non-fatal).
+      const dims =
+        (await this.resolveClipResolution()) === "720p"
+          ? "1280x720"
+          : "1920x1080";
+      const fps = await this.resolveClipFps();
+      const outroEnv = await this.resolveOutroBranding(dims, fps);
+      for (const [name, value] of Object.entries(outroEnv)) {
+        env.push({ name, value });
+      }
+    }
     env.push(...(await this.buildNodeCs2OptionsEnv(nodeId)));
 
     this.logger.log(

--- a/src/matches/game-streamer/game-streamer.service.ts
+++ b/src/matches/game-streamer/game-streamer.service.ts
@@ -19,6 +19,13 @@ import { GameStreamerStatusDto } from "./types/GameStreamerStatusDto";
 import { AppConfig } from "../../configs/types/AppConfig";
 import { SteamConfig } from "../../configs/types/SteamConfig";
 import { resolveInClusterApiBase } from "../clips/clips.constants";
+import { S3Service } from "../../s3/s3.service";
+import {
+  DEFAULT_OUTRO_ACCENT,
+  computeOutroVersion,
+  outroCacheKey,
+  buildOutroEnv,
+} from "./outro-branding";
 import { LoggingService } from "../../k8s/logging/logging.service";
 import {
   SteamAccountService,
@@ -160,6 +167,7 @@ export class GameStreamerService {
     private readonly demoMetadata: DemoMetadataService,
     private readonly loggingService: LoggingService,
     private readonly steamAccounts: SteamAccountService,
+    private readonly s3: S3Service,
   ) {
     this.gameServerConfig = this.config.get<GameServersConfig>("gameServers");
     this.appConfig = this.config.get<AppConfig>("app");
@@ -341,6 +349,61 @@ export class GameStreamerService {
       process.env.CLIP_BAKE_BRANDING ??
       "1";
     return value === "false" || value === "0" ? "0" : "1";
+  }
+
+  // Branded outro env for the render pod. Active only when a custom logo is
+  // set. Returns {} (stock outro), a presigned cache URL (hit), or a render
+  // instruction + presigned PUT + branding props (miss). Best-effort: any
+  // failure returns {} so the pod falls back to the baked stock outro.
+  public async resolveOutroBranding(
+    dims: string,
+    fps: number,
+  ): Promise<Record<string, string>> {
+    try {
+      const logoPath = await this.readSetting("public.logo_url");
+      if (!logoPath) {
+        return {};
+      }
+      const brandName = (await this.readSetting("public.brand_name")) ?? "";
+      const accent =
+        (await this.readSetting("public.color_dark_tactical_amber")) ??
+        (await this.readSetting("public.color_tactical_amber")) ??
+        DEFAULT_OUTRO_ACCENT;
+
+      let etag = logoPath;
+      try {
+        etag = (await this.s3.stat(logoPath))?.etag ?? logoPath;
+      } catch {
+        /* keep logoPath as the version seed */
+      }
+
+      const version = computeOutroVersion({ brandName, accent, etag });
+      const key = outroCacheKey({ version, dims, fps });
+
+      if (await this.s3.has(key)) {
+        return buildOutroEnv({
+          hit: true,
+          cacheUrl: await this.s3.getPresignedUrl(key, undefined, 3600, "get"),
+        });
+      }
+      return buildOutroEnv({
+        hit: false,
+        putUrl: await this.s3.getPresignedUrl(key, undefined, 3600, "put"),
+        logoUrl: await this.s3.getPresignedUrl(
+          logoPath,
+          undefined,
+          3600,
+          "get",
+        ),
+        brandName,
+        accent,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `resolveOutroBranding failed: ${(error as Error)?.message ?? error}`,
+      );
+      return {};
+    }
   }
 
   public async resolveClipFps(): Promise<30 | 60> {

--- a/src/matches/game-streamer/outro-branding.spec.ts
+++ b/src/matches/game-streamer/outro-branding.spec.ts
@@ -1,0 +1,48 @@
+import {
+  DEFAULT_OUTRO_ACCENT,
+  computeOutroVersion,
+  outroCacheKey,
+  buildOutroEnv,
+} from "./outro-branding";
+
+describe("outro-branding", () => {
+  it("default accent is the stock amber triple", () => {
+    expect(DEFAULT_OUTRO_ACCENT).toBe("33 94% 58%");
+  });
+
+  it("version is deterministic and 12 chars", () => {
+    const a = computeOutroVersion({ brandName: "ACME", accent: "1 2% 3%", etag: "e1" });
+    const b = computeOutroVersion({ brandName: "ACME", accent: "1 2% 3%", etag: "e1" });
+    expect(a).toBe(b);
+    expect(a).toHaveLength(12);
+  });
+
+  it("version changes when the logo etag changes", () => {
+    const a = computeOutroVersion({ brandName: "ACME", accent: "1 2% 3%", etag: "e1" });
+    const b = computeOutroVersion({ brandName: "ACME", accent: "1 2% 3%", etag: "e2" });
+    expect(a).not.toBe(b);
+  });
+
+  it("cache key embeds version + dims + fps", () => {
+    expect(outroCacheKey({ version: "abc123abc123", dims: "1920x1080", fps: 60 }))
+      .toBe("branding/outro_abc123abc123_1920x1080_60.mp4");
+  });
+
+  it("hit env is just the cache URL", () => {
+    expect(buildOutroEnv({ hit: true, cacheUrl: "http://s3/x.mp4" }))
+      .toEqual({ CLIP_OUTRO_URL: "http://s3/x.mp4" });
+  });
+
+  it("miss env carries render instruction + branding props", () => {
+    expect(buildOutroEnv({
+      hit: false, putUrl: "http://put", logoUrl: "http://logo",
+      brandName: "ACME", accent: "33 94% 58%",
+    })).toEqual({
+      CLIP_OUTRO_RENDER: "1",
+      CLIP_OUTRO_PUT_URL: "http://put",
+      CLIP_BRAND_LOGO_URL: "http://logo",
+      CLIP_BRAND_NAME: "ACME",
+      CLIP_BRAND_ACCENT: "33 94% 58%",
+    });
+  });
+});

--- a/src/matches/game-streamer/outro-branding.ts
+++ b/src/matches/game-streamer/outro-branding.ts
@@ -21,25 +21,31 @@ export function outroCacheKey(args: {
   return `branding/outro_${args.version}_${args.dims}_${args.fps}.mp4`;
 }
 
-export type OutroEnvState =
-  | { hit: true; cacheUrl: string }
-  | {
-      hit: false;
-      putUrl: string;
-      logoUrl: string;
-      brandName: string;
-      accent: string;
-    };
+export interface OutroEnvHit {
+  hit: true;
+  cacheUrl: string;
+}
+export interface OutroEnvMiss {
+  hit: false;
+  putUrl: string;
+  logoUrl: string;
+  brandName: string;
+  accent: string;
+}
+export type OutroEnvState = OutroEnvHit | OutroEnvMiss;
 
+// The api's tsconfig has strict mode off, so a boolean discriminant does not
+// narrow the union in the else branch — cast to the concrete variant instead.
 export function buildOutroEnv(state: OutroEnvState): Record<string, string> {
   if (state.hit) {
-    return { CLIP_OUTRO_URL: state.cacheUrl };
+    return { CLIP_OUTRO_URL: (state as OutroEnvHit).cacheUrl };
   }
+  const miss = state as OutroEnvMiss;
   return {
     CLIP_OUTRO_RENDER: "1",
-    CLIP_OUTRO_PUT_URL: state.putUrl,
-    CLIP_BRAND_LOGO_URL: state.logoUrl,
-    CLIP_BRAND_NAME: state.brandName,
-    CLIP_BRAND_ACCENT: state.accent,
+    CLIP_OUTRO_PUT_URL: miss.putUrl,
+    CLIP_BRAND_LOGO_URL: miss.logoUrl,
+    CLIP_BRAND_NAME: miss.brandName,
+    CLIP_BRAND_ACCENT: miss.accent,
   };
 }

--- a/src/matches/game-streamer/outro-branding.ts
+++ b/src/matches/game-streamer/outro-branding.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+
+export const DEFAULT_OUTRO_ACCENT = "33 94% 58%";
+
+export function computeOutroVersion(parts: {
+  brandName: string;
+  accent: string;
+  etag: string;
+}): string {
+  return createHash("sha1")
+    .update(`${parts.brandName}|${parts.accent}|${parts.etag}`)
+    .digest("hex")
+    .slice(0, 12);
+}
+
+export function outroCacheKey(args: {
+  version: string;
+  dims: string;
+  fps: number;
+}): string {
+  return `branding/outro_${args.version}_${args.dims}_${args.fps}.mp4`;
+}
+
+export type OutroEnvState =
+  | { hit: true; cacheUrl: string }
+  | {
+      hit: false;
+      putUrl: string;
+      logoUrl: string;
+      brandName: string;
+      accent: string;
+    };
+
+export function buildOutroEnv(state: OutroEnvState): Record<string, string> {
+  if (state.hit) {
+    return { CLIP_OUTRO_URL: state.cacheUrl };
+  }
+  return {
+    CLIP_OUTRO_RENDER: "1",
+    CLIP_OUTRO_PUT_URL: state.putUrl,
+    CLIP_BRAND_LOGO_URL: state.logoUrl,
+    CLIP_BRAND_NAME: state.brandName,
+    CLIP_BRAND_ACCENT: state.accent,
+  };
+}


### PR DESCRIPTION
**Part 2 of 2: `api` (merge AFTER the game-streamer PR).** Renderer: the `feature/branded-outro` PR in `5stackgg/game-streamer`. Full design, both PRs, and merge order: 5stackgg/5stack-panel#514.

## What

The **orchestration** half of the branded highlight outro: the api decides the outro cache hit/miss per render and passes branding env to the game-streamer render pod. The renderer PR consumes that env.

## Changes

- **`src/matches/game-streamer/outro-branding.ts`** (new): pure helpers. `computeOutroVersion` = `sha1(brandName|accent|logoEtag).slice(0,12)`, `outroCacheKey` = `branding/outro_<version>_<dims>_<fps>.mp4`, `buildOutroEnv`. `outro-branding.spec.ts` has 6 unit tests.
- **`game-streamer.service.ts`**: injects `S3Service`; `resolveOutroBranding(dims, fps)`:
  - active only when a custom logo (`public.logo_url`) is set;
  - accent = `public.color_dark_tactical_amber`, then `public.color_tactical_amber`, then default `33 94% 58%`;
  - seeds the cache version from the logo's **S3 ETag** (so a same-path logo re-upload invalidates);
  - presigns a cache **GET** on hit, or a **PUT** plus branding props on miss;
  - returns `{}` (which means baked stock outro) when no logo is set **or on any error**, so it never breaks a render.

  Wired into the batch-highlights pod env (pod-level) and the `dispatchClipRenderToPod` payload.
- **`src/matches/clips/clips.service.ts`**: passes `outro_env` in the on-demand dispatch payload.

No DB migration, no `web` change (reuses the existing branding settings).

## Env contract (shared with the renderer PR)

Same six keys: `CLIP_OUTRO_URL` (hit), **or** `CLIP_OUTRO_RENDER=1` + `CLIP_OUTRO_PUT_URL` + `CLIP_BRAND_LOGO_URL` + `CLIP_BRAND_NAME` + `CLIP_BRAND_ACCENT` (miss).

## Merge order

**Merge AFTER** the `game-streamer` PR (which must ship `:latest` first). Safe either way thanks to the stock fallback, but the renderer must be updated before the api turns the feature on.

## Verification

- `jest` 6/6 on the pure helpers; changed files `tsc --noEmit` clean (pre-existing project tsc errors, e.g. `sharp`, are unrelated).
- Whole-branch review on the most capable model verified the `S3Service` signatures, DI wiring, failure isolation, the exact env-name contract, and dims/fps consistency between the batch and on-demand paths. **Ready to merge, no Critical/Important findings.**

### Non-blocking follow-ups
- Parallelize the independent settings reads (`Promise.all`) on the cold path.
- Add a resolver-orchestration unit test (no-logo returns `{}`, hit/miss env, stat-throws degrades). The pure helpers are tested; the orchestration was verified by review.
