### PR TITLE
bug: inline season range check in flag_seasons_needs_rebuild migration

### DIFF
--- a/hasura/migrations/default/1867000000200_flag_seasons_needs_rebuild/up.sql
+++ b/hasura/migrations/default/1867000000200_flag_seasons_needs_rebuild/up.sql
@@ -1,10 +1,14 @@
+-- Migrations run before hasura/functions are applied, so this cannot call
+-- season_for_timestamp(); inline its range check instead (non-overlap of
+-- seasons is enforced by an exclusion constraint, so at most one matches).
 UPDATE public.seasons s
 SET needs_rebuild = true
 WHERE EXISTS (
     SELECT 1 FROM matches m
     WHERE m.source = '5stack'
       AND m.ended_at IS NOT NULL
-      AND season_for_timestamp(m.ended_at) = s.id
+      AND m.ended_at >= s.starts_at
+      AND (s.ends_at IS NULL OR m.ended_at < s.ends_at)
       AND NOT EXISTS (
           SELECT 1 FROM tournament_brackets tb WHERE tb.match_id = m.id
       )


### PR DESCRIPTION
Migrations run before hasura/functions are applied, so migration
1867000000200 failed on databases that don't yet have
season_for_timestamp(), crash-looping the api pod during setup and
preventing the functions/views (schedule_tournament_match, v_team_ranks)
from ever being applied.

Inline the season range check instead of calling the helper; seasons
cannot overlap (exclusion constraint), so the semantics are identical.
The failed migration was rolled back with its transaction, so the fixed
version applies cleanly on the next boot.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015XPPDUhkHmXZKRpfL1fqvV