### PR TITLE
feature: beta release channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,17 @@ on:
   push:
     branches:
       - "main"
+      - "beta"
   workflow_dispatch:
 
 concurrency:
-  group: build
+  group: build-${{ github.ref_name }}
   cancel-in-progress: true
-  
+
+env:
+  CHANNEL: ${{ github.ref_name == 'main' && 'latest' || 'beta' }}
+  TAG_PREFIX: ${{ github.ref_name != 'main' && 'beta-' || '' }}
+
 jobs:
   build-amd64:
     runs-on: ubuntu-24.04
@@ -31,11 +36,11 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:buildcache-amd64
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:buildcache-amd64,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:buildcache-${{ env.TAG_PREFIX }}amd64
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:buildcache-${{ env.TAG_PREFIX }}amd64,mode=max
           tags: |
-            ghcr.io/${{ github.repository_owner }}/api:latest-amd64
-            ghcr.io/${{ github.repository_owner }}/api:${{ github.sha }}-amd64
+            ghcr.io/${{ github.repository_owner }}/api:${{ env.CHANNEL }}-amd64
+            ghcr.io/${{ github.repository_owner }}/api:${{ env.TAG_PREFIX }}${{ github.sha }}-amd64
   build-arm64:
     runs-on: ubuntu-24.04-arm
     steps:
@@ -56,14 +61,16 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/arm64
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:buildcache-arm64
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:buildcache-arm64,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:buildcache-${{ env.TAG_PREFIX }}arm64
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:buildcache-${{ env.TAG_PREFIX }}arm64,mode=max
           tags: |
-            ghcr.io/${{ github.repository_owner }}/api:latest-arm64
-            ghcr.io/${{ github.repository_owner }}/api:${{ github.sha }}-arm64
+            ghcr.io/${{ github.repository_owner }}/api:${{ env.CHANNEL }}-arm64
+            ghcr.io/${{ github.repository_owner }}/api:${{ env.TAG_PREFIX }}${{ github.sha }}-arm64
   merge:
     needs: [build-amd64, build-arm64]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v3
@@ -73,16 +80,44 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest list and push
         run: |
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/api:latest \
-            ghcr.io/${{ github.repository_owner }}/api:latest-amd64 \
-            ghcr.io/${{ github.repository_owner }}/api:latest-arm64
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/api:${{ github.sha }} \
-            ghcr.io/${{ github.repository_owner }}/api:${{ github.sha }}-amd64 \
-            ghcr.io/${{ github.repository_owner }}/api:${{ github.sha }}-arm64
-      - name: Delete Package Versions
-        uses: actions/delete-package-versions@v5
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/api:${{ env.CHANNEL }} \
+            ghcr.io/${{ github.repository_owner }}/api:${{ env.CHANNEL }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/api:${{ env.CHANNEL }}-arm64
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/api:${{ env.TAG_PREFIX }}${{ github.sha }} \
+            ghcr.io/${{ github.repository_owner }}/api:${{ env.TAG_PREFIX }}${{ github.sha }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/api:${{ env.TAG_PREFIX }}${{ github.sha }}-arm64
+      - name: Prune old images for channel
+        uses: actions/github-script@v7
         with:
-          package-name: api
-          package-type: container
-          min-versions-to-keep: 9
-          ignore-versions: '^buildcache-*'
+          script: |
+            const channel = context.ref === 'refs/heads/main' ? 'main' : 'beta';
+            const keep = 9;
+            const owner = context.repo.owner;
+            const pkg = 'api';
+            const isBuildcache = (t) => t.startsWith('buildcache');
+            const isBeta = (t) => t === 'beta' || t.startsWith('beta-');
+            const { data: ownerInfo } = await github.rest.users.getByUsername({ username: owner });
+            const isOrg = ownerInfo.type === 'Organization';
+            const listFn = isOrg
+              ? github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg
+              : github.rest.packages.getAllPackageVersionsForPackageOwnedByUser;
+            const listArgs = isOrg
+              ? { package_type: 'container', package_name: pkg, org: owner, per_page: 100 }
+              : { package_type: 'container', package_name: pkg, username: owner, per_page: 100 };
+            const versions = await github.paginate(listFn, listArgs);
+            const inChannel = versions.filter((v) => {
+              const tags = v.metadata?.container?.tags || [];
+              if (tags.length === 0) return false;
+              if (tags.some(isBuildcache)) return false;
+              const beta = tags.some(isBeta);
+              return channel === 'beta' ? beta : !beta;
+            });
+            inChannel.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            const toDelete = inChannel.slice(keep);
+            for (const v of toDelete) {
+              await (isOrg
+                ? github.rest.packages.deletePackageVersionForOrg({ package_type: 'container', package_name: pkg, org: owner, package_version_id: v.id })
+                : github.rest.packages.deletePackageVersionForUser({ package_type: 'container', package_name: pkg, username: owner, package_version_id: v.id }));
+              core.info(`deleted ${pkg} ${v.id} [${(v.metadata?.container?.tags || []).join(', ')}]`);
+            }
+            core.info(`channel=${channel} candidates=${inChannel.length} deleted=${toDelete.length}`);

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -576,6 +576,12 @@ type Mutation {
 }
 
 type Mutation {
+  setReleaseChannel(
+    channel: String!
+  ): SuccessOutput
+}
+
+type Mutation {
   resumeClipRenderBatch(
     match_map_id: uuid!
   ): SuccessOutput

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -869,6 +869,14 @@ actions:
       forward_client_headers: true
     permissions:
       - role: administrator
+  - name: setReleaseChannel
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_GRAPHQL_ACTIONS_HOOK}}'
+      forward_client_headers: true
+    permissions:
+      - role: administrator
+    comment: Switch the platform release channel (latest | beta); admin only.
   - name: resumeClipRenderBatch
     definition:
       kind: synchronous

--- a/src/dedicated-servers/dedicated-servers.module.ts
+++ b/src/dedicated-servers/dedicated-servers.module.ts
@@ -14,6 +14,7 @@ import { getQueuesProcessors } from "src/utilities/QueueProcessors";
 import { RconModule } from "src/rcon/rcon.module";
 import { RedisModule } from "src/redis/redis.module";
 import { SystemModule } from "src/system/system.module";
+import { ReleaseChannelModule } from "src/release-channel/release-channel.module";
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { SystemModule } from "src/system/system.module";
     RconModule,
     RedisModule,
     SystemModule,
+    ReleaseChannelModule,
   ],
   providers: [
     DedicatedServersService,

--- a/src/dedicated-servers/dedicated-servers.service.ts
+++ b/src/dedicated-servers/dedicated-servers.service.ts
@@ -10,6 +10,7 @@ import { RconService } from "src/rcon/rcon.service";
 import { RedisManagerService } from "src/redis/redis-manager/redis-manager.service";
 import { Redis } from "ioredis";
 import { SystemService } from "src/system/system.service";
+import { ReleaseChannelService } from "src/release-channel/release-channel.service";
 
 @Injectable()
 export class DedicatedServersService {
@@ -30,6 +31,7 @@ export class DedicatedServersService {
     private readonly RconService: RconService,
     private readonly redisManager: RedisManagerService,
     private readonly systemService: SystemService,
+    private readonly releaseChannel: ReleaseChannelService,
   ) {
     this.redis = this.redisManager.getConnection();
 
@@ -135,6 +137,8 @@ export class DedicatedServersService {
           /:.+$/,
           `:v${pinPluginVersion.toString()}`,
         );
+      } else {
+        pluginImage = await this.releaseChannel.resolveChannelImage(pluginImage);
       }
 
       const dedicatedServerDeploymentName =

--- a/src/game-server-node/game-server-node.module.ts
+++ b/src/game-server-node/game-server-node.module.ts
@@ -31,6 +31,7 @@ import { K8sModule } from "src/k8s/k8s.module";
 import { GameStreamerModule } from "../matches/game-streamer/game-streamer.module";
 import { BakeShaders } from "./jobs/BakeShaders";
 import { ValidateGamedata } from "./jobs/ValidateGamedata";
+import { ReleaseChannelModule } from "src/release-channel/release-channel.module";
 
 @Module({
   providers: [
@@ -55,6 +56,7 @@ import { ValidateGamedata } from "./jobs/ValidateGamedata";
     RconModule,
     K8sModule,
     GameStreamerModule,
+    ReleaseChannelModule,
     BullModule.registerQueue(
       {
         name: GameServerQueues.GameUpdate,

--- a/src/game-server-node/game-server-node.service.ts
+++ b/src/game-server-node/game-server-node.service.ts
@@ -21,6 +21,7 @@ import { NodeDisk } from "./interfaces/NodeDisk";
 import { InjectQueue } from "@nestjs/bullmq";
 import { Queue } from "bullmq";
 import { GameServerQueues } from "./enums/GameServerQueues";
+import { ReleaseChannelService } from "src/release-channel/release-channel.service";
 
 export type GamedataValidationResult = {
   build_id?: number | null;
@@ -61,6 +62,7 @@ export class GameServerNodeService {
     protected readonly hasura: HasuraService,
     redisManager: RedisManagerService,
     protected readonly loggingService: LoggingService,
+    protected readonly releaseChannel: ReleaseChannelService,
     @InjectQueue(GameServerQueues.ValidateGamedata)
     private readonly validateGamedataQueue: Queue,
   ) {
@@ -477,6 +479,10 @@ export class GameServerNodeService {
         ? `serverfiles-csgo-${sanitizedGameServerNodeId}`
         : `serverfiles-${sanitizedGameServerNodeId}`;
 
+    const updateImage = await this.releaseChannel.resolveChannelImage(
+      "ghcr.io/5stackgg/game-server:latest",
+    );
+
     try {
       await this.batchApi.createNamespacedJob({
         namespace: this.namespace,
@@ -524,7 +530,7 @@ export class GameServerNodeService {
                 containers: [
                   {
                     name: "update-cs-server",
-                    image: "ghcr.io/5stackgg/game-server:latest",
+                    image: updateImage,
                     command: ["/opt/scripts/update.sh"],
                     env: [
                       {
@@ -880,6 +886,10 @@ export class GameServerNodeService {
       return null;
     }
 
+    const validatorImage = await this.releaseChannel.resolveChannelImage(
+      "ghcr.io/5stackgg/gamedata-validator:latest",
+    );
+
     try {
       await this.batchApi
         .deleteNamespacedJob({
@@ -931,7 +941,7 @@ export class GameServerNodeService {
                 containers: [
                   {
                     name: "validate-gamedata",
-                    image: "ghcr.io/5stackgg/gamedata-validator:latest",
+                    image: validatorImage,
                     args: ["--build-id", buildId.toString()],
                     volumeMounts: [
                       {

--- a/src/matches/game-streamer/game-streamer.module.ts
+++ b/src/matches/game-streamer/game-streamer.module.ts
@@ -17,6 +17,7 @@ import { S3Module } from "../../s3/s3.module";
 import { RedisModule } from "../../redis/redis.module";
 import { DemosModule } from "../../demos/demos.module";
 import { K8sModule } from "../../k8s/k8s.module";
+import { ReleaseChannelModule } from "../../release-channel/release-channel.module";
 import { loggerFactory } from "../../utilities/LoggerFactory";
 
 @Module({
@@ -28,6 +29,7 @@ import { loggerFactory } from "../../utilities/LoggerFactory";
     RedisModule,
     DemosModule,
     K8sModule,
+    ReleaseChannelModule,
   ],
   controllers: [
     GameStreamerController,

--- a/src/matches/game-streamer/game-streamer.service.ts
+++ b/src/matches/game-streamer/game-streamer.service.ts
@@ -20,6 +20,7 @@ import { AppConfig } from "../../configs/types/AppConfig";
 import { SteamConfig } from "../../configs/types/SteamConfig";
 import { resolveInClusterApiBase } from "../clips/clips.constants";
 import { LoggingService } from "../../k8s/logging/logging.service";
+import { ReleaseChannelService } from "../../release-channel/release-channel.service";
 import {
   SteamAccountService,
   ClaimedSteamAccount,
@@ -140,6 +141,7 @@ export class GameStreamerService {
     private readonly demoMetadata: DemoMetadataService,
     private readonly loggingService: LoggingService,
     private readonly steamAccounts: SteamAccountService,
+    private readonly releaseChannel: ReleaseChannelService,
   ) {
     this.gameServerConfig = this.config.get<GameServersConfig>("gameServers");
     this.appConfig = this.config.get<AppConfig>("app");
@@ -782,7 +784,7 @@ export class GameStreamerService {
 
     await batch.createNamespacedJob({
       namespace: this.namespace,
-      body: this.buildJobSpec(
+      body: await this.buildJobSpec(
         jobName,
         matchId,
         "demo",
@@ -1477,7 +1479,7 @@ export class GameStreamerService {
     try {
       await batch.createNamespacedJob({
         namespace: this.namespace,
-        body: this.buildJobSpec(
+        body: await this.buildJobSpec(
           jobName,
           matchId,
           "live",
@@ -2197,7 +2199,7 @@ export class GameStreamerService {
     try {
       await batch.createNamespacedJob({
         namespace: this.namespace,
-        body: this.buildJobSpec(
+        body: await this.buildJobSpec(
           jobName,
           matchId,
           "batch-highlights",
@@ -2785,7 +2787,7 @@ export class GameStreamerService {
 
     await batch.createNamespacedJob({
       namespace: this.namespace,
-      body: this.buildJobSpec(
+      body: await this.buildJobSpec(
         jobName,
         gameServerNodeId,
         "warm-shaders",
@@ -3003,7 +3005,7 @@ export class GameStreamerService {
     });
   }
 
-  private buildJobSpec(
+  private async buildJobSpec(
     jobName: string,
     matchId: string,
     mode: StreamerMode,
@@ -3011,7 +3013,10 @@ export class GameStreamerService {
     extraEnv: V1EnvVar[],
     extraLabels: Record<string, string> = {},
     steamAccount: ClaimedSteamAccount | null = null,
-  ): V1Job {
+  ): Promise<V1Job> {
+    const gameStreamerImage = await this.releaseChannel.resolveChannelImage(
+      this.gameServerConfig.gameStreamerImage,
+    );
     const steamUser = steamAccount?.username ?? this.steamConfig.steamUser;
     const steamPassword =
       steamAccount?.password ?? this.steamConfig.steamPassword;
@@ -3099,7 +3104,7 @@ export class GameStreamerService {
               {
                 name: containerName,
                 // Override via GAME_STREAMER_IMAGE (see configs/game-servers.ts).
-                image: this.gameServerConfig.gameStreamerImage,
+                image: gameStreamerImage,
                 // Mutable tag; force each pod start to resolve the latest digest.
                 imagePullPolicy: "Always",
                 securityContext: { privileged: true },

--- a/src/matches/match-assistant/match-assistant.service.spec.ts
+++ b/src/matches/match-assistant/match-assistant.service.spec.ts
@@ -57,6 +57,9 @@ describe("MatchAssistantService", () => {
       hasura as any,
       {} as any,
       loggingService as any,
+      {
+        resolveChannelImage: jest.fn(async (image: string) => image),
+      } as any,
       queue as any,
     );
   });

--- a/src/matches/match-assistant/match-assistant.service.ts
+++ b/src/matches/match-assistant/match-assistant.service.ts
@@ -27,6 +27,7 @@ import { AppConfig } from "src/configs/types/AppConfig";
 import { FailedToCreateOnDemandServer } from "../errors/FailedToCreateOnDemandServer";
 import { LoggingService } from "src/k8s/logging/logging.service";
 import type { MatchServerBootDiagnostic } from "src/k8s/logging/bootDiagnostics";
+import { ReleaseChannelService } from "src/release-channel/release-channel.service";
 
 @Injectable()
 export class MatchAssistantService {
@@ -57,6 +58,7 @@ export class MatchAssistantService {
     private readonly hasura: HasuraService,
     private readonly encryption: EncryptionService,
     private readonly loggingService: LoggingService,
+    private readonly releaseChannel: ReleaseChannelService,
     @InjectQueue(MatchQueues.MatchServers) private queue: Queue,
   ) {
     this.appConfig = this.config.get<AppConfig>("app");
@@ -759,6 +761,9 @@ export class MatchAssistantService {
               /:.+$/,
               `:v${pinPluginVersion.toString()}`,
             );
+          } else {
+            pluginImage =
+              await this.releaseChannel.resolveChannelImage(pluginImage);
           }
 
           const fivestackRanksSettingName = match.is_tournament_match

--- a/src/matches/matches.module.ts
+++ b/src/matches/matches.module.ts
@@ -62,10 +62,12 @@ import { GameStreamerModule } from "./game-streamer/game-streamer.module";
 import { DemosModule } from "../demos/demos.module";
 import { ClipsModule } from "./clips/clips.module";
 import { SteamMatchHistoryModule } from "../steam-match-history/steam-match-history.module";
+import { ReleaseChannelModule } from "src/release-channel/release-channel.module";
 
 @Module({
   imports: [
     HasuraModule,
+    ReleaseChannelModule,
     forwardRef(() => RconModule),
     CacheModule,
     RedisModule,

--- a/src/release-channel/release-channel.module.ts
+++ b/src/release-channel/release-channel.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { ReleaseChannelService } from "./release-channel.service";
+import { CacheModule } from "../cache/cache.module";
+import { PostgresModule } from "../postgres/postgres.module";
+import { loggerFactory } from "../utilities/LoggerFactory";
+
+@Module({
+  imports: [CacheModule, PostgresModule],
+  exports: [ReleaseChannelService],
+  providers: [ReleaseChannelService, loggerFactory()],
+})
+export class ReleaseChannelModule {}

--- a/src/release-channel/release-channel.service.ts
+++ b/src/release-channel/release-channel.service.ts
@@ -1,0 +1,86 @@
+import fetch from "node-fetch";
+import { Injectable, Logger } from "@nestjs/common";
+import { CacheService } from "src/cache/cache.service";
+import { PostgresService } from "src/postgres/postgres.service";
+import { SystemSettingName } from "src/system/enums/SystemSettingName";
+
+@Injectable()
+export class ReleaseChannelService {
+  constructor(
+    private readonly logger: Logger,
+    private readonly cache: CacheService,
+    private readonly postgres: PostgresService,
+  ) {}
+
+  public async getReleaseChannel(): Promise<"latest" | "beta"> {
+    const [data] = await this.postgres.query<
+      Array<{
+        value: string;
+      }>
+    >(`SELECT value FROM public.settings WHERE name = $1 LIMIT 1`, [
+      SystemSettingName.ReleaseChannel,
+    ]);
+
+    return data?.value === "beta" ? "beta" : "latest";
+  }
+
+  public async resolveChannelImage(image: string): Promise<string> {
+    const channel = await this.getReleaseChannel();
+    if (channel !== "beta") {
+      return image;
+    }
+
+    const match = image.match(/^ghcr\.io\/5stackgg\/([^/:]+):[^:]+$/);
+    if (!match) {
+      return image;
+    }
+
+    const registry = match[1];
+    if (!(await this.channelTagExists(registry, "beta"))) {
+      return image;
+    }
+
+    return image.replace(/:[^:/]+$/, ":beta");
+  }
+
+  public async channelTagExists(
+    registry: string,
+    tag: string,
+  ): Promise<boolean> {
+    return await this.cache.remember<boolean>(
+      `channel-tag:${registry}:${tag}`,
+      async () => {
+        try {
+          const token = await this.getToken(registry);
+          const response = await fetch(
+            `https://ghcr.io/v2/5stackgg/${registry}/manifests/${tag}`,
+            {
+              method: "HEAD",
+              headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: "application/vnd.oci.image.index.v1+json",
+              },
+            },
+          );
+          return response.ok;
+        } catch (error) {
+          this.logger.warn(
+            `Unable to check channel tag ${registry}:${tag}`,
+            error,
+          );
+          return false;
+        }
+      },
+      300,
+    );
+  }
+
+  private async getToken(image: string) {
+    const tokenResponse = await fetch(
+      `https://ghcr.io/token?scope=repository:5stackgg/${image}:pull`,
+    );
+    const { token } = await tokenResponse.json();
+
+    return token;
+  }
+}

--- a/src/system/enums/SystemSettingName.ts
+++ b/src/system/enums/SystemSettingName.ts
@@ -10,4 +10,6 @@ export enum SystemSettingName {
   NewsLabel = "public.news_label",
   PostNewsRole = "public.post_news_role",
   RequireLoginForLiveStreams = "public.require_login_for_live_streams",
+  ReleaseChannel = "release_channel",
+  ReleaseChannelStatus = "release_channel_status",
 }

--- a/src/system/jobs/CheckSystemUpdateJob.ts
+++ b/src/system/jobs/CheckSystemUpdateJob.ts
@@ -11,5 +11,6 @@ export class CheckSystemUpdateJob extends WorkerHost {
 
   async process(): Promise<void> {
     await this.system.setVersions();
+    await this.system.reconcileChannelImages();
   }
 }

--- a/src/system/system.controller.ts
+++ b/src/system/system.controller.ts
@@ -160,6 +160,31 @@ export class SystemController {
   }
 
   @HasuraAction()
+  public async setReleaseChannel(data: { channel: string }) {
+    const channel = data.channel === "beta" ? "beta" : "latest";
+
+    await this.hasura.mutation({
+      insert_settings_one: {
+        __args: {
+          object: {
+            name: SystemSettingName.ReleaseChannel,
+            value: channel,
+          },
+          on_conflict: {
+            constraint: "settings_pkey",
+            update_columns: ["value"],
+          },
+        },
+        __typename: true,
+      },
+    });
+
+    return {
+      success: true,
+    };
+  }
+
+  @HasuraAction()
   public async registerName(data: { user: User; name: string }) {
     await this.hasura.mutation({
       update_players_by_pk: {
@@ -293,6 +318,16 @@ export class SystemController {
     ) {
       const ttl = parseInt(data.new.value, 10);
       await this.chatService.updateChatMessageTTL(isNaN(ttl) ? 60 * 60 : ttl);
+    }
+
+    if (
+      (data.new.name === SystemSettingName.ReleaseChannel ||
+        data.old.name === SystemSettingName.ReleaseChannel) &&
+      (data.op === "INSERT" ||
+        data.op === "DELETE" ||
+        data.new.value !== data.old.value)
+    ) {
+      void this.system.updateServices();
     }
 
     await this.system.updateDefaultOptions();

--- a/src/system/system.module.ts
+++ b/src/system/system.module.ts
@@ -20,6 +20,7 @@ import { K8sModule } from "src/k8s/k8s.module";
 import { ChatModule } from "src/chat/chat.module";
 import { SystemSettingName } from "./enums/SystemSettingName";
 import { ChatService } from "src/chat/chat.service";
+import { ReleaseChannelModule } from "src/release-channel/release-channel.module";
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { ChatService } from "src/chat/chat.service";
     S3Module,
     PostgresModule,
     ChatModule,
+    ReleaseChannelModule,
     BullModule.registerQueue({
       name: SystemQueues.Version,
     }),

--- a/src/system/system.service.ts
+++ b/src/system/system.service.ts
@@ -15,6 +15,7 @@ import { DiscordConfig } from "src/configs/types/DiscordConfig";
 import { SteamConfig } from "src/configs/types/SteamConfig";
 import { PostgresService } from "src/postgres/postgres.service";
 import { SystemSettingName } from "./enums/SystemSettingName";
+import { ReleaseChannelService } from "src/release-channel/release-channel.service";
 
 @Injectable()
 export class SystemService {
@@ -36,6 +37,18 @@ export class SystemService {
     "hasura",
   ];
 
+  private static CHANNEL_WORKLOADS: Record<
+    string,
+    { kind: "Deployment" | "DaemonSet"; initContainer?: string }
+  > = {
+    api: { kind: "Deployment" },
+    web: { kind: "Deployment" },
+    "demo-parser": { kind: "Deployment" },
+    hasura: { kind: "Deployment", initContainer: "migrations" },
+    "game-server-node-connector": { kind: "DaemonSet" },
+    "game-server-node-connector-nvidia": { kind: "DaemonSet" },
+  };
+
   private serviceRegistry(service: string) {
     return SystemService.SERVICE_TO_REGISTRY[service] ?? service;
   }
@@ -46,6 +59,7 @@ export class SystemService {
     private readonly config: ConfigService,
     private readonly logger: Logger,
     private readonly postgres: PostgresService,
+    private readonly releaseChannel: ReleaseChannelService,
   ) {
     const kc = new KubeConfig();
     kc.loadFromDefault();
@@ -166,16 +180,129 @@ export class SystemService {
   }
 
   public async updateServices() {
+    const patchedServices = await this.reconcileChannelImages();
     const services = await this.getServices();
     const latestVersions = await this.getLatestVersions();
 
     for (const { pod, service, version } of Object.values(services)) {
-      if (version === latestVersions[this.serviceRegistry(service)]) {
+      if (patchedServices.has(service)) {
+        continue;
+      }
+
+      const target = latestVersions[this.serviceRegistry(service)];
+
+      if (!target || version === target.digest) {
         continue;
       }
 
       void this.restartService(service, pod);
     }
+  }
+
+  public async reconcileChannelImages(): Promise<Set<string>> {
+    const latestVersions = await this.getLatestVersions();
+    const patched = new Set<string>();
+
+    for (const [service, workload] of Object.entries(
+      SystemService.CHANNEL_WORKLOADS,
+    )) {
+      const target = latestVersions[this.serviceRegistry(service)];
+      if (!target) {
+        continue;
+      }
+
+      try {
+        const container = await this.getWorkloadContainer(service, workload);
+        if (!container?.image) {
+          continue;
+        }
+
+        const currentTag = container.image.match(/:([^:/]+)$/)?.[1] ?? "latest";
+        if (currentTag === target.tag) {
+          continue;
+        }
+
+        const image = container.image.replace(/:[^:/]+$/, `:${target.tag}`);
+        await this.setWorkloadImage(service, workload, container.name, image);
+        patched.add(service);
+      } catch (error) {
+        this.logger.warn(
+          `Unable to reconcile channel image for ${service}`,
+          error,
+        );
+      }
+    }
+
+    return patched;
+  }
+
+  private async getWorkloadContainer(
+    service: string,
+    workload: { kind: "Deployment" | "DaemonSet"; initContainer?: string },
+    namespace = "5stack",
+  ) {
+    try {
+      const resource =
+        workload.kind === "DaemonSet"
+          ? await this.appsClient.readNamespacedDaemonSet({
+              name: service,
+              namespace,
+            })
+          : await this.appsClient.readNamespacedDeployment({
+              name: service,
+              namespace,
+            });
+
+      const spec = resource.spec?.template?.spec;
+
+      if (workload.initContainer) {
+        return spec?.initContainers?.find(
+          (container) => container.name === workload.initContainer,
+        );
+      }
+
+      return spec?.containers?.[0];
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async setWorkloadImage(
+    service: string,
+    workload: { kind: "Deployment" | "DaemonSet"; initContainer?: string },
+    containerName: string,
+    image: string,
+    namespace = "5stack",
+  ) {
+    const podSpec = workload.initContainer
+      ? { initContainers: [{ name: containerName, image }] }
+      : { containers: [{ name: containerName, image }] };
+
+    const patch = {
+      name: service,
+      namespace,
+      body: {
+        spec: {
+          template: {
+            spec: podSpec,
+          },
+        },
+      },
+    };
+
+    if (workload.kind === "DaemonSet") {
+      await this.appsClient.patchNamespacedDaemonSet(
+        patch,
+        setHeaderOptions("Content-Type", PatchStrategy.StrategicMergePatch),
+      );
+    } else {
+      await this.appsClient.patchNamespacedDeployment(
+        patch,
+        setHeaderOptions("Content-Type", PatchStrategy.StrategicMergePatch),
+      );
+    }
+
+    this.logger.log(`Set ${workload.kind} ${service} image to ${image}`);
   }
 
   public async restartService(service: string, pod?: string) {
@@ -193,8 +320,9 @@ export class SystemService {
         await this.restartPod(pod);
       }
     } finally {
+      const channel = await this.releaseChannel.getReleaseChannel();
       await this.cache.forget(
-        this.getServiceCacheKey(this.serviceRegistry(service)),
+        this.getServiceCacheKey(channel, this.serviceRegistry(service)),
       );
     }
   }
@@ -213,17 +341,18 @@ export class SystemService {
       });
     }
 
+    const channel = await this.releaseChannel.getReleaseChannel();
     const services = await this.getServices();
     const latestVersions = await this.getLatestVersions();
 
     for (const { service, version, pod } of Object.values(services)) {
-      const latestVersion = latestVersions[this.serviceRegistry(service)];
-      if (version !== latestVersion) {
+      const target = latestVersions[this.serviceRegistry(service)];
+      if (target && version !== target.digest) {
         hasUpdates.push({
           service,
           pod,
           currentVersion: version,
-          newVersion: latestVersion,
+          newVersion: target.digest,
         });
       }
     }
@@ -243,57 +372,97 @@ export class SystemService {
         __typename: true,
       },
     });
+
+    const channelStatus = Object.entries(latestVersions)
+      .filter(([service]) => service !== "hasura")
+      .map(([service, target]) => ({
+        service,
+        tag: target.tag,
+        fellBack: channel === "beta" && target.tag !== "beta",
+      }));
+
+    await this.hasura.mutation({
+      insert_settings_one: {
+        __args: {
+          object: {
+            name: SystemSettingName.ReleaseChannelStatus,
+            value: JSON.stringify({ channel, services: channelStatus }),
+          },
+          on_conflict: {
+            constraint: "settings_pkey",
+            update_columns: ["value"],
+          },
+        },
+        __typename: true,
+      },
+    });
   }
 
-  public async getLatestVersions(): Promise<Record<string, string>> {
+  public async getLatestVersions(): Promise<
+    Record<string, { digest: string; tag: string }>
+  > {
+    const channel = await this.releaseChannel.getReleaseChannel();
     const registries = [
       "api",
       "web",
       "game-server-node-connector",
       "demo-parser",
     ];
-    const latestVersions: Record<string, string> = {};
+    const latestVersions: Record<string, { digest: string; tag: string }> = {};
 
     for (const registry of registries) {
       const data = await this.cache.remember<{
         service: string;
-        latestVersion: string;
+        digest: string;
+        tag: string;
       }>(
-        this.getServiceCacheKey(registry),
+        this.getServiceCacheKey(channel, registry),
         async () => {
-          const token = await this.getToken(registry);
-          const latestManifestResponse = await fetch(
-            `https://ghcr.io/v2/5stackgg/${registry}/manifests/latest`,
-            {
-              headers: {
-                Authorization: `Bearer ${token}`,
-                Accept: "application/vnd.oci.image.index.v1+json",
-              },
-            },
+          const { digest, tag } = await this.fetchChannelManifest(
+            registry,
+            channel,
           );
-
-          if (!latestManifestResponse.ok) {
-            throw new Error(
-              `Failed to fetch manifest [${registry}]: ${latestManifestResponse.statusText}`,
-            );
-          }
-
-          return {
-            service: registry,
-            latestVersion: latestManifestResponse.headers.get(
-              "docker-content-digest",
-            ),
-          };
+          return { service: registry, digest, tag };
         },
         300,
       );
 
-      latestVersions[data.service] = data.latestVersion;
+      latestVersions[data.service] = { digest: data.digest, tag: data.tag };
     }
 
     latestVersions.hasura = latestVersions.api;
 
     return latestVersions;
+  }
+
+  private async fetchChannelManifest(registry: string, channel: string) {
+    const tags = channel === "latest" ? ["latest"] : ["beta", "latest"];
+
+    const token = await this.getToken(registry);
+
+    let lastError: string;
+    for (const tag of tags) {
+      const response = await fetch(
+        `https://ghcr.io/v2/5stackgg/${registry}/manifests/${tag}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.oci.image.index.v1+json",
+          },
+        },
+      );
+
+      if (response.ok) {
+        return {
+          digest: response.headers.get("docker-content-digest"),
+          tag,
+        };
+      }
+
+      lastError = response.statusText;
+    }
+
+    throw new Error(`Failed to fetch manifest [${registry}]: ${lastError}`);
   }
 
   public async restartPod(pod: string) {
@@ -409,8 +578,8 @@ export class SystemService {
     return token;
   }
 
-  private getServiceCacheKey(service: string) {
-    return `version:v2:${service}`;
+  private getServiceCacheKey(channel: string, service: string) {
+    return `version:v3:${channel}:${service}`;
   }
 
   private async getPanelVersion() {
@@ -428,7 +597,7 @@ export class SystemService {
 
   private async getLatestPanelVersion() {
     return await this.cache.remember<string>(
-      this.getServiceCacheKey("panel"),
+      this.getServiceCacheKey("na", "panel"),
       async () => {
         try {
           const response = await fetch(


### PR DESCRIPTION
Admins can switch the install between `latest` and a new `beta` release channel from the web panel. Pairs with the web PR (selector UI) and the 5stack-panel PR (DaemonSet RBAC); the other repos' PRs add their beta channel builds.

## How it works
- New admin-only `release_channel` setting (`latest` | `beta`) set via a new `setReleaseChannel` hasura action; a settings event triggers an immediate reconcile
- `getLatestVersions` queries the GHCR manifest for the selected channel with **per-service fallback to `latest`** when a repo has no beta image yet — a half-built beta degrades gracefully instead of breaking the install
- `reconcileChannelImages` patches workload image tags to the desired channel: Deployments (api, web, demo-parser), DaemonSets (game-server-node-connector + nvidia variant), and the hasura `migrations` init container. Runs every minute from `CheckSystemUpdateJob`, so kustomize reapplies (which pin `:latest`) self-correct; digest-based restarts remain manual via `updateServices`
- New `ReleaseChannelService` (cache + postgres deps only, avoiding module cycles) resolves runtime images at creation: match game-server pods (`pin_plugin_version` still wins), game-streamer jobs, and the update-cs-server / validate-gamedata jobs — each with a cached GHCR existence check and `:latest` fallback
- `release_channel_status` setting exposes per-service tag + fallback state to the web UI

## CI
- Build the `beta` branch: `beta`, `beta-<sha>` tags with per-channel buildcache; main is unchanged
- Tag-based per-channel prune replaces `delete-package-versions`, whose `ignore-versions` matches version digests rather than container tags (actions/delete-package-versions#120) — without this a beta channel head could be evicted by main-build churn

## Deploy notes
- `hasura metadata apply` needed for the `setReleaseChannel` action
- Panel RBAC PR must be applied before DaemonSet reconcile works (fails safe as a logged warning until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)