### PR TITLE
feat: pre-warm tailscale path to k3s server on game node start

### DIFF
--- a/src/game-server-node/game-server-node.controller.ts
+++ b/src/game-server-node/game-server-node.controller.ts
@@ -715,6 +715,15 @@ cat <<-'DROPIN' >/etc/systemd/system/k3s-agent.service.d/tailscale-state-check.c
 	ExecStartPre=/usr/local/bin/5stack-tailscale-state-check.sh
 DROPIN
 
+cat <<-'DROPIN' >/etc/systemd/system/k3s-agent.service.d/tailscale-prewarm.conf
+	[Unit]
+	After=tailscaled.service
+	Wants=tailscaled.service
+
+	[Service]
+	ExecStartPre=-/bin/bash -c '. /etc/systemd/system/k3s-agent.service.env 2>/dev/null || true; H=$(echo "\${K3S_URL#*://}" | cut -d: -f1 | cut -d/ -f1); [ -n "$H" ] && echo "[5stack] pre-warming tailscale path to $H" && timeout 15 tailscale ping -c 3 "$H" >/dev/null 2>&1 || true'
+DROPIN
+
 cat <<-'UNIT' >/etc/systemd/system/5stack-tailscale-state-check.service
 	[Unit]
 	Description=5stack tailscale state check


### PR DESCRIPTION
## Problem

`GET /game-server-node/script/:id` (`game-server-node.controller.ts`) generates the `curl | bash` script the panel gives you to add a game/GPU node. It provisions the node as a **k3s agent** joining the control plane over Tailscale.

After a reboot, the Tailscale **direct** path to the k3s server can come up **one-way** (`tx>0, rx 0`). `tailscaled` self-reports healthy (`BackendState=Running`, empty `Health`), so the existing `5stack-tailscale-state-check` passes every cycle, yet the agent cannot reach the control plane. `k3s-agent` then loops on `failed to get CA certs ... context deadline exceeded`, never joins the cluster, no pods (including `game-server-node-connector`) schedule, and the node shows **Offline** in the panel.

Observed live: a GPU node stuck ~27 min after a reboot; a manual `tailscale ping <server>` re-established the path and it recovered on its own within one retry.

## Fix

Add a best-effort `ExecStartPre` drop-in (`tailscale-prewarm.conf`, in `k3s-agent.service.d`) that runs **before** `k3s-agent` starts: if `K3S_URL` is set, it does a bounded `tailscale ping` to the server, forcing Tailscale's NAT traversal to (re)establish the direct path bidirectionally, so k3s-agent never validates against a dead one-way path.

- Prefixed with `-` and wrapped in `|| true` so a failed or hung pre-warm **can never block `k3s-agent` from starting** (the ping is bounded by `timeout 15`).
- Does not touch the existing `tailscale-state-check` logic or the other drop-ins.

## Relationship to 5stack-panel#573

This is the **canonical** agent-provisioning path, so it is the one that protects all future nodes added via the panel. 5stack-panel#573 adds the same pre-warm to the separate `game-node-server-setup.sh` (standalone-server setup, where it is a no-op).

## Testing

- Installed the identical drop-in on a live agent node and verified end to end through a transient systemd unit: `K3S_URL=https://100.90.141.113:6443` parses to `100.90.141.113`, the ping ponged, and it is non-blocking.
- Confirmed the generated shell renders correctly from the JS template literal (escaped `\${...}` becomes `${...}`, bare `$H` preserved); `tsc` clean and backtick balance even.

## Note

Guards the reboot case (path warmed at startup). It does not add steady-state one-way-path detection to the periodic `tailscale-state-check`, which still only inspects tailscaled's self-reported health; that would be a follow-up.
