### PR TITLE
fix(steam-match-history): surface Steam 412 as a re-link hint

### DIFF
--- a/src/steam-match-history/steam-match-history.service.ts
+++ b/src/steam-match-history/steam-match-history.service.ts
@@ -389,6 +389,18 @@ export class SteamMatchHistoryService {
       if (response.status === 403) {
         return { nextCode: null, error: "invalid auth_code or share_code" };
       }
+      if (response.status === 412) {
+        // Steam returns 412 when the knowncode is not a valid share code for
+        // this account: a stale seed on the pollForUser walk, or a wrong code
+        // pasted into the linkAccount probe. fetchNextShareCode serves both
+        // callers, so keep this message context-neutral and actionable rather
+        // than the raw "responded with 412".
+        return {
+          nextCode: null,
+          error:
+            "share code not accepted, link again with your most recent share code",
+        };
+      }
       if (response.status === 202) {
         return { nextCode: null, error: null };
       }


### PR DESCRIPTION
## Problem

Linked Accounts shows a cryptic `steam web api responded with 412` in the "Last error" line, with no obvious way to recover from the UI.

Steam's `ICSGOPlayers_730/GetNextMatchSharingCode` returns **412 Precondition Failed** when the `knowncode` is not a valid share code for the account (a stale seed from an old link, or a wrong code pasted at link time). `fetchNextShareCode` special-cases `403`/`202`/`429` but dropped everything else, including `412`, into the generic `steam web api responded with ${status}` bucket.

`pollForUser` starts every poll from `last_known_share_code`, so it gets `412` on the first call, breaks, and re-records the same raw status on every run. The UI refresh button just re-polls the same bad seed, so the error is unrecoverable without knowing to update the share code.

## Fix

Special-case `412` alongside the existing status handling and return an actionable, **context-neutral** message:

> share code not accepted, link again with your most recent share code

`fetchNextShareCode` is shared by `pollForUser` (the walk) and `linkAccount`'s first-time probe, so the wording deliberately avoids assuming an existing link, matching the neutral `403`/`429` strings. It renders in the Linked Accounts "Last error" line and inline at link time. Re-linking updates `last_known_share_code` via the existing `on_conflict`, which clears the stuck state.

## Scope / notes

- One-file change; mirrors the existing `403`/`202`/`429` branches in `fetchNextShareCode`.
- No behavior change for any other status, and no change to poll cadence: `412` already broke the walk and tripped the standard 10-minute cooldown before this PR, only the surfaced string changes.
- No schema or UI change; reuses the existing `last_error` surfacing.
